### PR TITLE
Remove unnecessary module inputs

### DIFF
--- a/nixvim.nix
+++ b/nixvim.nix
@@ -1,6 +1,4 @@
-{ config, pkgs, inputs, ... }:
-
-{
+{pkgs, ...}: {
   imports = [
     # NOTE: The first thing you will want to do is uncommented on of the three imports below
     # depending on which module you chose to use to install Nixvim.
@@ -323,7 +321,6 @@
         '';
       }
     ];
-
 
     plugins = {
       # Detect tabstop and shiftwidth automatically

--- a/nixvim.nix
+++ b/nixvim.nix
@@ -1,4 +1,4 @@
-{pkgs, ...}: {
+{ pkgs, inputs, ... }: {
   imports = [
     # NOTE: The first thing you will want to do is uncommented on of the three imports below
     # depending on which module you chose to use to install Nixvim.

--- a/plugins/conform.nix
+++ b/plugins/conform.nix
@@ -1,6 +1,4 @@
-{ config, pkgs, inputs, ... }:
-
-{
+{pkgs, ...}: {
   programs.nixvim = {
     # Dependencies
     #
@@ -16,25 +14,25 @@
       enable = true;
       notifyOnError = false;
       formatOnSave = ''
-	function(bufnr)
-	  -- Disable "format_on_save lsp_fallback" for lanuages that don't
-	  -- have a well standardized coding style. You can add additional
-	  -- lanuages here or re-enable it for the disabled ones.
-	  local disable_filetypes = { c = true, cpp = true }
-	  return {
-	    timeout_ms = 500,
-	    lsp_fallback = not disable_filetypes[vim.bo[bufnr].filetype]
-	  }
-	end
+        function(bufnr)
+          -- Disable "format_on_save lsp_fallback" for lanuages that don't
+          -- have a well standardized coding style. You can add additional
+          -- lanuages here or re-enable it for the disabled ones.
+          local disable_filetypes = { c = true, cpp = true }
+          return {
+            timeout_ms = 500,
+            lsp_fallback = not disable_filetypes[vim.bo[bufnr].filetype]
+          }
+        end
       '';
       formattersByFt = {
-	lua = ["stylua"];
-	# Conform can also run multiple formatters sequentially
-	# python = [ "isort "black" ];
-	#
-	# You can use a sublist to tell conform to run *until* a formatter
-	# is found
-	# javascript = [ [ "prettierd" "prettier" ] ];
+        lua = ["stylua"];
+        # Conform can also run multiple formatters sequentially
+        # python = [ "isort "black" ];
+        #
+        # You can use a sublist to tell conform to run *until* a formatter
+        # is found
+        # javascript = [ [ "prettierd" "prettier" ] ];
       };
     };
 
@@ -42,15 +40,15 @@
     keymaps = [
       {
         mode = "";
-	key = "<leader>f";
-	action.__raw = ''
-	  function()
-	    require('conform').format { async = true, lsp_fallback = true }
-	  end
-	'';
-	options = {
-	  desc = "[F]ormat buffer";
-	};
+        key = "<leader>f";
+        action.__raw = ''
+          function()
+            require('conform').format { async = true, lsp_fallback = true }
+          end
+        '';
+        options = {
+          desc = "[F]ormat buffer";
+        };
       }
     ];
   };

--- a/plugins/gitsigns.nix
+++ b/plugins/gitsigns.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Adds git related signs to the gutter, as well as utilities for managing changes
@@ -8,214 +6,214 @@
     plugins.gitsigns = {
       enable = true;
       settings = {
-	signs = {
-	  add = { text = "+"; };
-	  change = { text = "~"; };
-	  delete = { text = "_"; };
-	  topdelete = { text = "‾"; };
-	  changedelete = { text = "~"; };
-	};
+        signs = {
+          add = {text = "+";};
+          change = {text = "~";};
+          delete = {text = "_";};
+          topdelete = {text = "‾";};
+          changedelete = {text = "~";};
+        };
       };
     };
 
     # NOTE: add gitsigns recommended keymaps if you are interested
     /*
-    # https://nix-community.github.io/nixvim/keymaps/index.html
-    keymaps = [
-      # Navigation
-      {
-        mode = "n";
-	key = "]c";
-	action.__raw = ''
-	  function()
-	    if vim.wo.diff then
-	      vim.cmd.normal { ']c', bang = true }
-	    else
-	      require('gitsigns').nav_hunk 'next'
-	    end
-	  end
-	'';
-	options = {
-	  desc = "Jump to next git [C]hange";
-	};
-      }
-      {
-        mode = "n";
-	key = "[c";
-	action.__raw = ''
-	  function()
-	    if vim.wo.diff then
-	      vim.cmd.normal { '[c', bang = true }
-	    else
-	      require('gitsigns').nav_hunk 'prev'
-	    end
-	  end
-	'';
-	options = {
-	  desc = "Jump to previous git [C]hange";
-	};
-      }
-      # Actions
-      # visual mode
-      {
-        mode = "v";
-	key = "<leader>hs";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
-	  end
-	'';
-	options = {
-	  desc = "stage git hunk";
-	};
-      }
-      {
-        mode = "v";
-	key = "<leader>hr";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
-	  end
-	'';
-	options = {
-	  desc = "reset git hunk";
-	};
-      }
-      # normal mode
-      {
-        mode = "n";
-	key = "<leader>hs";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').stage_hunk()
-	  end
-	'';
-	options = {
-	  desc = "git [s]tage hunk";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hr";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').reset_hunk()
-	  end
-	'';
-	options = {
-	  desc = "git [r]eset hunk";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hS";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').stage_buffer()
-	  end
-	'';
-	options = {
-	  desc = "git [S]tage buffer";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hu";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').undo_stage_hunk()
-	  end
-	'';
-	options = {
-	  desc = "git [u]ndo stage hunk";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hR";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').reset_buffer()
-	  end
-	'';
-	options = {
-	  desc = "git [R]eset buffer";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hp";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').preview_hunk()
-	  end
-	'';
-	options = {
-	  desc = "git [p]review hunk";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hb";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').blame_line()
-	  end
-	'';
-	options = {
-	  desc = "git [b]lame line";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hd";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').diffthis()
-	  end
-	'';
-	options = {
-	  desc = "git [d]iff against index";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>hD";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').diffthis '@'
-	  end
-	'';
-	options = {
-	  desc = "git [D]iff against last commit";
-	};
-      }
-      # Toggles
-      {
-        mode = "n";
-	key = "<leader>tb";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').toggle_current_line_blame()
-	  end
-	'';
-	options = {
-	  desc = "[T]oggle git show [b]lame line";
-	};
-      }
-      {
-        mode = "n";
-	key = "<leader>tD";
-	action.__raw = ''
-	  function()
-	    require('gitsigns').toggle_deleted()
-	  end
-	'';
-	options = {
-	  desc = "[T]oggle git show [D]eleted";
-	};
-      }
-    ];
+       # https://nix-community.github.io/nixvim/keymaps/index.html
+       keymaps = [
+         # Navigation
+         {
+           mode = "n";
+    key = "]c";
+    action.__raw = ''
+      function()
+        if vim.wo.diff then
+          vim.cmd.normal { ']c', bang = true }
+        else
+          require('gitsigns').nav_hunk 'next'
+        end
+      end
+    '';
+    options = {
+      desc = "Jump to next git [C]hange";
+    };
+         }
+         {
+           mode = "n";
+    key = "[c";
+    action.__raw = ''
+      function()
+        if vim.wo.diff then
+          vim.cmd.normal { '[c', bang = true }
+        else
+          require('gitsigns').nav_hunk 'prev'
+        end
+      end
+    '';
+    options = {
+      desc = "Jump to previous git [C]hange";
+    };
+         }
+         # Actions
+         # visual mode
+         {
+           mode = "v";
+    key = "<leader>hs";
+    action.__raw = ''
+      function()
+        require('gitsigns').stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
+      end
+    '';
+    options = {
+      desc = "stage git hunk";
+    };
+         }
+         {
+           mode = "v";
+    key = "<leader>hr";
+    action.__raw = ''
+      function()
+        require('gitsigns').reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
+      end
+    '';
+    options = {
+      desc = "reset git hunk";
+    };
+         }
+         # normal mode
+         {
+           mode = "n";
+    key = "<leader>hs";
+    action.__raw = ''
+      function()
+        require('gitsigns').stage_hunk()
+      end
+    '';
+    options = {
+      desc = "git [s]tage hunk";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hr";
+    action.__raw = ''
+      function()
+        require('gitsigns').reset_hunk()
+      end
+    '';
+    options = {
+      desc = "git [r]eset hunk";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hS";
+    action.__raw = ''
+      function()
+        require('gitsigns').stage_buffer()
+      end
+    '';
+    options = {
+      desc = "git [S]tage buffer";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hu";
+    action.__raw = ''
+      function()
+        require('gitsigns').undo_stage_hunk()
+      end
+    '';
+    options = {
+      desc = "git [u]ndo stage hunk";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hR";
+    action.__raw = ''
+      function()
+        require('gitsigns').reset_buffer()
+      end
+    '';
+    options = {
+      desc = "git [R]eset buffer";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hp";
+    action.__raw = ''
+      function()
+        require('gitsigns').preview_hunk()
+      end
+    '';
+    options = {
+      desc = "git [p]review hunk";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hb";
+    action.__raw = ''
+      function()
+        require('gitsigns').blame_line()
+      end
+    '';
+    options = {
+      desc = "git [b]lame line";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hd";
+    action.__raw = ''
+      function()
+        require('gitsigns').diffthis()
+      end
+    '';
+    options = {
+      desc = "git [d]iff against index";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>hD";
+    action.__raw = ''
+      function()
+        require('gitsigns').diffthis '@'
+      end
+    '';
+    options = {
+      desc = "git [D]iff against last commit";
+    };
+         }
+         # Toggles
+         {
+           mode = "n";
+    key = "<leader>tb";
+    action.__raw = ''
+      function()
+        require('gitsigns').toggle_current_line_blame()
+      end
+    '';
+    options = {
+      desc = "[T]oggle git show [b]lame line";
+    };
+         }
+         {
+           mode = "n";
+    key = "<leader>tD";
+    action.__raw = ''
+      function()
+        require('gitsigns').toggle_deleted()
+      end
+    '';
+    options = {
+      desc = "[T]oggle git show [D]eleted";
+    };
+         }
+       ];
     */
   };
 }

--- a/plugins/kickstart/health.nix
+++ b/plugins/kickstart/health.nix
@@ -1,53 +1,51 @@
-{ config, pkgs, inputs, ... }:
-
 {
   # This file is not required for your own configuration,
   # but helps people determine if their system is setup correctly
   #
   programs.nixvim = {
     extraConfigLua = ''
-      local check_version = function()
-	local verstr = string.format('%s.%s.%s', vim.version().major, vim.version().minor, vim.version().patch)
-	if not vim.version.cmp then
-	  vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
-	  return
-	end
-
-	if vim.version.cmp(vim.version(), { 0, 9, 4 }) >= 0 then
-	  vim.health.ok(string.format("Neovim version is: '%s'", verstr))
-	else
-	  vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
-	end
+           local check_version = function()
+      local verstr = string.format('%s.%s.%s', vim.version().major, vim.version().minor, vim.version().patch)
+      if not vim.version.cmp then
+        vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
+        return
       end
 
-      local check_external_reqs = function()
-	-- Basic utils: `git`, `make`, `unzip`
-	for _, exe in ipairs { 'git', 'make', 'unzip', 'rg' } do
-	  local is_executable = vim.fn.executable(exe) == 1
-	  if is_executable then
-	    vim.health.ok(string.format("Found executable: '%s'", exe))
-	  else
-	    vim.health.warn(string.format("Could not find executable: '%s'", exe))
-	  end
-	end
+      if vim.version.cmp(vim.version(), { 0, 9, 4 }) >= 0 then
+        vim.health.ok(string.format("Neovim version is: '%s'", verstr))
+      else
+        vim.health.error(string.format("Neovim out of date: '%s'. Upgrade to latest stable or nightly", verstr))
+      end
+           end
 
-	return true
+           local check_external_reqs = function()
+      -- Basic utils: `git`, `make`, `unzip`
+      for _, exe in ipairs { 'git', 'make', 'unzip', 'rg' } do
+        local is_executable = vim.fn.executable(exe) == 1
+        if is_executable then
+          vim.health.ok(string.format("Found executable: '%s'", exe))
+        else
+          vim.health.warn(string.format("Could not find executable: '%s'", exe))
+        end
       end
 
-      check = function()
-	vim.health.start 'kickstart.nvim'
+      return true
+           end
 
-	vim.health.info [[NOTE: Not every warning is a 'must-fix' in `:checkhealth`
+           check = function()
+      vim.health.start 'kickstart.nvim'
 
-      Fix only warnings for plugins and languages you intend to use.
-	You do not need to install, unless you want to use those languages!]]
+      vim.health.info [[NOTE: Not every warning is a 'must-fix' in `:checkhealth`
 
-	local uv = vim.uv or vim.loop
-	vim.health.info('System Information: ' .. vim.inspect(uv.os_uname()))
+           Fix only warnings for plugins and languages you intend to use.
+      You do not need to install, unless you want to use those languages!]]
 
-	check_version()
-	check_external_reqs()
-      end
+      local uv = vim.uv or vim.loop
+      vim.health.info('System Information: ' .. vim.inspect(uv.os_uname()))
+
+      check_version()
+      check_external_reqs()
+           end
     '';
   };
 }

--- a/plugins/kickstart/plugins/autopairs.nix
+++ b/plugins/kickstart/plugins/autopairs.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   # Inserts matching pairs of parens, brackets, etc.
   # https://nix-community.github.io/nixvim/plugins/nvim-autopairs/index.html

--- a/plugins/kickstart/plugins/debug.nix
+++ b/plugins/kickstart/plugins/debug.nix
@@ -1,13 +1,11 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
-  # Shows how to use the DAP plugin to debug your code.
-  #
-  # Primarily focused on configuring the debugger for Go, but can
-  # be extended to other languages as well. That's why it's called
-  # kickstart.nixvim and not ktichen-sink.nixvim ;)
-  # https://nix-community.github.io/nixvim/plugins/dap/index.html
+    # Shows how to use the DAP plugin to debug your code.
+    #
+    # Primarily focused on configuring the debugger for Go, but can
+    # be extended to other languages as well. That's why it's called
+    # kickstart.nixvim and not ktichen-sink.nixvim ;)
+    # https://nix-community.github.io/nixvim/plugins/dap/index.html
     plugins.dap = {
       enable = true;
 
@@ -19,7 +17,7 @@
           # Set icons to characters that are more likely to work in every terminal.
           # Feel free to remove or use ones that you like more! :)
           # Don't feel like these are good choices.
-          icons = { 
+          icons = {
             expanded = "▾";
             collapsed = "▸";
             current_frame = "*";

--- a/plugins/kickstart/plugins/indent-blankline.nix
+++ b/plugins/kickstart/plugins/indent-blankline.nix
@@ -1,10 +1,8 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
-  # Add indentation guides even on blank lines
-  # For configuration see `:help ibl`
-  # https://nix-community.github.io/nixvim/plugins/indent-blankline/index.html
+    # Add indentation guides even on blank lines
+    # For configuration see `:help ibl`
+    # https://nix-community.github.io/nixvim/plugins/indent-blankline/index.html
     plugins.indent-blankline = {
       enable = true;
     };

--- a/plugins/kickstart/plugins/lint.nix
+++ b/plugins/kickstart/plugins/lint.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Linting

--- a/plugins/kickstart/plugins/neo-tree.nix
+++ b/plugins/kickstart/plugins/neo-tree.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Neo-tree is a Neovim plugin to browse the file system

--- a/plugins/lsp.nix
+++ b/plugins/lsp.nix
@@ -1,6 +1,4 @@
-{ config, pkgs, inputs, ... }:
-
-{
+{pkgs, ...}: {
   programs.nixvim = {
     # Dependencies
     #
@@ -15,7 +13,7 @@
       enable = true;
     };
 
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraplugi#extraplugins 
+    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraplugi#extraplugins
     extraPlugins = with pkgs.vimPlugins; [
       # NOTE: This is how you would ad a vim plugin that is not implemented in Nixvim, also see extraConfigLuaPre below
       # `neodev` configure Lua LSP for your Neovim config, runtime and plugins

--- a/plugins/mini.nix
+++ b/plugins/mini.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Collection of various small independent plugins/modules
@@ -37,7 +35,6 @@
         # ... and there is more!
         # Check out: https://github.com/echasnovski/mini.nvim
       };
-
     };
 
     # You can configure sections in the statusline by overriding their

--- a/plugins/nvim-cmp.nix
+++ b/plugins/nvim-cmp.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Dependencies
@@ -43,89 +41,89 @@
 
       settings = {
         snippet = {
-	  expand = ''
-	    function(args)
-	      require('luasnip').lsp_expand(args.body)
-	    end
-	  '';
-	};
+          expand = ''
+            function(args)
+              require('luasnip').lsp_expand(args.body)
+            end
+          '';
+        };
 
-	completion = {
-	  completeopt = "menu,menuone,noinsert";
-	};
+        completion = {
+          completeopt = "menu,menuone,noinsert";
+        };
 
-	# For an understanding of why these mappings were
-	# chosen, you will need to read `:help ins-completion`
-	#
-	# No, but seriously, Please read `:help ins-completion`, it is really good!
-	mapping = {
-	  # Select the [n]ext item
-	  "<C-n>" = "cmp.mapping.select_next_item()";
-	  # Select the [p]revious item
-	  "<C-p>" = "cmp.mapping.select_prev_item()";
-	  # Scroll the documentation window [b]ack / [f]orward
-	  "<C-b>" = "cmp.mapping.scroll_docs(-4)";
-	  "<C-f>" = "cmp.mapping.scroll_docs(4)";
-	  # Accept ([y]es) the completion.
-	  #  This will auto-import if your LSP supports it.
-	  #  This will expand snippets if the LSP sent a snippet.
-	  "<C-y>" = "cmp.mapping.confirm { select = true }";
-	  # If you prefer more traditional completion keymaps,
-	  # you can uncomment the following lines.
-	  # "<CR>" = "cmp.mapping.confirm { select = true }";
-	  # "<Tab>" = "cmp.mapping.select_next_item()";
-	  # "<S-Tab>" = "cmp.mapping.select_prev_item()";
+        # For an understanding of why these mappings were
+        # chosen, you will need to read `:help ins-completion`
+        #
+        # No, but seriously, Please read `:help ins-completion`, it is really good!
+        mapping = {
+          # Select the [n]ext item
+          "<C-n>" = "cmp.mapping.select_next_item()";
+          # Select the [p]revious item
+          "<C-p>" = "cmp.mapping.select_prev_item()";
+          # Scroll the documentation window [b]ack / [f]orward
+          "<C-b>" = "cmp.mapping.scroll_docs(-4)";
+          "<C-f>" = "cmp.mapping.scroll_docs(4)";
+          # Accept ([y]es) the completion.
+          #  This will auto-import if your LSP supports it.
+          #  This will expand snippets if the LSP sent a snippet.
+          "<C-y>" = "cmp.mapping.confirm { select = true }";
+          # If you prefer more traditional completion keymaps,
+          # you can uncomment the following lines.
+          # "<CR>" = "cmp.mapping.confirm { select = true }";
+          # "<Tab>" = "cmp.mapping.select_next_item()";
+          # "<S-Tab>" = "cmp.mapping.select_prev_item()";
 
-	  # Manually trigger a completion from nvim-cmp.
-	  #  Generally you don't need this, because nvim-cmp will display
-	  #  completions whenever it has completion options available.
-	  "<C-Space>" = "cmp.mapping.complete {}";
-	  
-	  # Think of <c-l> as moving to the right of your snippet expansion.
-	  #  So if you have a snippet that's like:
-	  #  function $name($args)
-	  #    $body
-	  #  end
-	  #
-	  # <c-l> will move you to the right of the expansion locations.
-	  # <c-h> is similar, except moving you backwards.
-	  "<C-l>" = ''
-	    cmp.mapping(function()
-	      if luasnip.expand_or_locally_jumpable() then
-	        luasnip.expand_or_jump()
-	      end
-	    end, { 'i', 's' })
-	  '';
-	  "<C-h>" = ''
-	    cmp.mapping(function()
-	      if luasnip.locally_jumpable(-1) then
-	        luasnip.jump(-1)
-	      end
-	    end, { 'i', 's' })
-	  '';
+          # Manually trigger a completion from nvim-cmp.
+          #  Generally you don't need this, because nvim-cmp will display
+          #  completions whenever it has completion options available.
+          "<C-Space>" = "cmp.mapping.complete {}";
 
-	  # For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
-	  #    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
-	};
+          # Think of <c-l> as moving to the right of your snippet expansion.
+          #  So if you have a snippet that's like:
+          #  function $name($args)
+          #    $body
+          #  end
+          #
+          # <c-l> will move you to the right of the expansion locations.
+          # <c-h> is similar, except moving you backwards.
+          "<C-l>" = ''
+            cmp.mapping(function()
+              if luasnip.expand_or_locally_jumpable() then
+                luasnip.expand_or_jump()
+              end
+            end, { 'i', 's' })
+          '';
+          "<C-h>" = ''
+            cmp.mapping(function()
+              if luasnip.locally_jumpable(-1) then
+                luasnip.jump(-1)
+              end
+            end, { 'i', 's' })
+          '';
 
-	# WARNING: If plugins.cmp.autoEnableSources Nixivm will automatically enable the 
-	# corresponding source plugins. This will work only when this option is set to a list.
+          # For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
+          #    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
+        };
+
+        # WARNING: If plugins.cmp.autoEnableSources Nixivm will automatically enable the
+        # corresponding source plugins. This will work only when this option is set to a list.
         # If you use a raw lua string, you will need to explicitly enable the relevant source
-	# plugins in your nixvim configuration.
+        # plugins in your nixvim configuration.
         sources = [
-	  {
-	    name = "luasnip";
-	  }
-	  # Adds other completion capabilites.
-	  #  nvim-cmp does not ship with all sources by default. They are split
-	  #  into multiple repos for maintenance purposes.
-	  {
-	    name = "nvim_lsp";
-	  }
-	  {
-	    name = "path";
-	  }
-	];
+          {
+            name = "luasnip";
+          }
+          # Adds other completion capabilites.
+          #  nvim-cmp does not ship with all sources by default. They are split
+          #  into multiple repos for maintenance purposes.
+          {
+            name = "nvim_lsp";
+          }
+          {
+            name = "path";
+          }
+        ];
       };
     };
   };

--- a/plugins/telescope.nix
+++ b/plugins/telescope.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Fuzzy Finder (files, lsp, etc)
@@ -30,86 +28,86 @@
 
       # Enable Telescope extensions
       extensions = {
-	fzf-native.enable = true;
-	ui-select.enable = true;
+        fzf-native.enable = true;
+        ui-select.enable = true;
       };
 
       # You can put your default mappings / updates / etc. in here
       #  See `:help telescope.builtin`
       keymaps = {
-	"<leader>sh" = {
-	  mode = "n";
-	  action = "help_tags";
-	  options = {
-	    desc = "[S]earch [H]elp";
-	  };
-	};
-	"<leader>sk" = {
-	  mode = "n";
-	  action = "keymaps";
-	  options = {
-	    desc = "[S]earch [K]eymaps";
-	  };
-	};
-	"<leader>sf" = {
-	  mode = "n";
-	  action = "find_files";
-	  options = {
-	    desc = "[S]earch [F]iles";
-	  };
-	};
-	"<leader>ss" = {
-	  mode = "n";
-	  action = "builtin";
-	  options = {
-	    desc = "[S]earch [S]elect Telescope";
-	  };
-	};
-	"<leader>sw" = {
-	  mode = "n";
-	  action = "grep_string";
-	  options = {
-	    desc = "[S]earch current [W]ord";
-	  };
-	};
-	"<leader>sg" = {
-	  mode = "n";
-	  action = "live_grep";
-	  options = {
-	    desc = "[S]earch by [G]rep";
-	  };
-	};
-	"<leader>sd" = {
-	  mode = "n";
-	  action = "diagnostics";
-	  options = {
-	    desc = "[S]earch [D]iagnostics";
-	  };
-	};
-	"<leader>sr" = {
-	  mode = "n";
-	  action = "resume";
-	  options = {
-	    desc = "[S]earch [R]esume";
-	  };
-	};
-	"<leader>s" = {
-	  mode = "n";
-	  action = "oldfiles";
-	  options = {
-	    desc = "[S]earch Recent Files ('.' for repeat)";
-	  };
-	};
-	"<leader><leader>" = {
-	  mode = "n";
-	  action = "buffers";
-	  options = {
-	    desc = "[ ] Find existing buffers";
-	  };
-	};
+        "<leader>sh" = {
+          mode = "n";
+          action = "help_tags";
+          options = {
+            desc = "[S]earch [H]elp";
+          };
+        };
+        "<leader>sk" = {
+          mode = "n";
+          action = "keymaps";
+          options = {
+            desc = "[S]earch [K]eymaps";
+          };
+        };
+        "<leader>sf" = {
+          mode = "n";
+          action = "find_files";
+          options = {
+            desc = "[S]earch [F]iles";
+          };
+        };
+        "<leader>ss" = {
+          mode = "n";
+          action = "builtin";
+          options = {
+            desc = "[S]earch [S]elect Telescope";
+          };
+        };
+        "<leader>sw" = {
+          mode = "n";
+          action = "grep_string";
+          options = {
+            desc = "[S]earch current [W]ord";
+          };
+        };
+        "<leader>sg" = {
+          mode = "n";
+          action = "live_grep";
+          options = {
+            desc = "[S]earch by [G]rep";
+          };
+        };
+        "<leader>sd" = {
+          mode = "n";
+          action = "diagnostics";
+          options = {
+            desc = "[S]earch [D]iagnostics";
+          };
+        };
+        "<leader>sr" = {
+          mode = "n";
+          action = "resume";
+          options = {
+            desc = "[S]earch [R]esume";
+          };
+        };
+        "<leader>s" = {
+          mode = "n";
+          action = "oldfiles";
+          options = {
+            desc = "[S]earch Recent Files ('.' for repeat)";
+          };
+        };
+        "<leader><leader>" = {
+          mode = "n";
+          action = "buffers";
+          options = {
+            desc = "[ ] Find existing buffers";
+          };
+        };
       };
       settings = {
-	extensions.__raw = "{ ['ui-select'] = { require('telescope.themes').get_dropdown() } }";
+        extensions.__raw = "{ ['ui-select'] = { require('telescope.themes').get_dropdown() } }";
       };
     };
 
@@ -118,35 +116,35 @@
       # Slightly advanced example of overriding default behavior and theme
       {
         mode = "n";
-	key = "<leader>/";
-	# You can pass additional configuration to Telescope to change the theme, layout, etc.
-	action.__raw = ''
-	  function()
-	    require('telescope.builtin').current_buffer_fuzzy_find(
-	      require('telescope.themes').get_dropdown {
-	        winblend = 10,
-	        previewer = false
-	      }
-	    )
-	  end
-	'';
-	options = {
+        key = "<leader>/";
+        # You can pass additional configuration to Telescope to change the theme, layout, etc.
+        action.__raw = ''
+          function()
+            require('telescope.builtin').current_buffer_fuzzy_find(
+              require('telescope.themes').get_dropdown {
+                winblend = 10,
+                previewer = false
+              }
+            )
+          end
+        '';
+        options = {
           desc = "[/] Fuzzily search in current buffer";
-	};
+        };
       }
       {
         mode = "n";
-	key = "<leader>s/";
+        key = "<leader>s/";
         # It's also possible to pass additional configuration options.
         #  See `:help telescope.builtin.live_grep()` for information about particular keys
-	action.__raw = ''
-	  function()
-	    require('telescope.builtin').live_grep {
-	      grep_open_files = true,
-	      prompt_title = 'Live Grep in Open Files'
-	    }
-	  end
-	'';
+        action.__raw = ''
+          function()
+            require('telescope.builtin').live_grep {
+              grep_open_files = true,
+              prompt_title = 'Live Grep in Open Files'
+            }
+          end
+        '';
         options = {
           desc = "[S]earch [/] in Open Files";
         };
@@ -154,16 +152,16 @@
       # Shortcut for searching your Neovim configuration files
       {
         mode = "n";
-	key = "<leader>sn";
-	action.__raw = ''
-	  function()
-	    require('telescope.builtin').find_files {
-	      cwd = vim.fn.stdpath 'config'
-	    }
-	  end
+        key = "<leader>sn";
+        action.__raw = ''
+          function()
+            require('telescope.builtin').find_files {
+              cwd = vim.fn.stdpath 'config'
+            }
+          end
         '';
         options = {
-	  desc = "[S]earch [N]eovim files";
+          desc = "[S]earch [N]eovim files";
         };
       }
     ];

--- a/plugins/treesitter.nix
+++ b/plugins/treesitter.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Highlight, edit, and navigate code
@@ -10,14 +8,14 @@
       # TODO: Don't think I need this as nixGrammars is true which should atuo install these???
       ensureInstalled = [
         "bash"
-	"c"
-	"diff"
-	"html"
-	"lua"
-	"luadoc"
-	"markdown"
-	"vim"
-	"vimdoc"
+        "c"
+        "diff"
+        "html"
+        "lua"
+        "luadoc"
+        "markdown"
+        "vim"
+        "vimdoc"
       ];
 
       # TODO: Figure out how to do this
@@ -34,11 +32,11 @@
 
       indent = true;
       #indent = {
-        #enable = true;
-	# TODO: Figure out how to do this
-	#disable = [
-	#  "ruby"
-	#];
+      #enable = true;
+      # TODO: Figure out how to do this
+      #disable = [
+      #  "ruby"
+      #];
       #};
 
       # There are additional nvim-treesitter modules that you can use to interact

--- a/plugins/which-key.nix
+++ b/plugins/which-key.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, inputs, ... }:
-
 {
   programs.nixvim = {
     # Useful plugin to show you pending keybinds.
@@ -9,34 +7,34 @@
 
       # Document existing key chains
       registrations = {
-	"<leader>c" = {
-	  name = "[C]ode";
-	  _ = "which_key_ignore";
-	};
-	"<leader>d" = {
-	  name = "[D]ocument";
-	  _ = "which_key_ignore";
-	};
-	"<leader>r" = {
-	  name = "[R]ename";
-	  _ = "which_key_ignore";
-	};
-	"<leader>s" = {
-	 name = "[S]earch";
-	 _ = "which_key_ignore";
-	};
-	"<leader>w" = {
-	  name = "[W]orkspace";
-	  _ = "which_key_ignore";
-	};
-	"<leader>t" = {
-	  name = "[T]oggle";
-	  _ = "which_key_ignore";
-	};
-	"<leader>h" = {
-	  name = "Git [H]unk";
-	  _ = "which_key_ignore";
-	};
+        "<leader>c" = {
+          name = "[C]ode";
+          _ = "which_key_ignore";
+        };
+        "<leader>d" = {
+          name = "[D]ocument";
+          _ = "which_key_ignore";
+        };
+        "<leader>r" = {
+          name = "[R]ename";
+          _ = "which_key_ignore";
+        };
+        "<leader>s" = {
+          name = "[S]earch";
+          _ = "which_key_ignore";
+        };
+        "<leader>w" = {
+          name = "[W]orkspace";
+          _ = "which_key_ignore";
+        };
+        "<leader>t" = {
+          name = "[T]oggle";
+          _ = "which_key_ignore";
+        };
+        "<leader>h" = {
+          name = "Git [H]unk";
+          _ = "which_key_ignore";
+        };
       };
     };
   };


### PR DESCRIPTION
First of all, thank you for this repo! This is exactly what I was looking for.

I noticed that you have `{config, pkgs, inputs, ...}:` at the beginning of every module, even though most don't end up using these inputs. So I went ahead and removed all such instances.