### PR TITLE
(cmp): don't specify dependencies explicitly since `sources` handles that

### DIFF
--- a/plugins/nvim-cmp.nix
+++ b/plugins/nvim-cmp.nix
@@ -1,23 +1,5 @@
 {
   programs.nixvim = {
-    # Dependencies
-    #
-    # Snippet Engine & its associated nvim-cmp source
-    # https://nix-community.github.io/nixvim/plugins/luasnip/index.html
-    plugins.luasnip = {
-      enable = true;
-    };
-
-    # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp.html
-    plugins.cmp-nvim-lsp = {
-      enable = true;
-    };
-
-    # https://nix-community.github.io/nixvim/plugins/cmp-path.html
-    plugins.cmp-path = {
-      enable = true;
-    };
-
     # `friendly-snippets` contains a variety of premade snippets
     #    See the README about individual language/framework/plugin snippets:
     #    https://github.com/rafamadriz/friendly-snippets
@@ -106,20 +88,26 @@
           #    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
         };
 
+        # Dependencies
+        #
         # WARNING: If plugins.cmp.autoEnableSources Nixivm will automatically enable the
         # corresponding source plugins. This will work only when this option is set to a list.
         # If you use a raw lua string, you will need to explicitly enable the relevant source
         # plugins in your nixvim configuration.
         sources = [
+          # Snippet Engine & its associated nvim-cmp source
+          # https://nix-community.github.io/nixvim/plugins/luasnip/index.html
           {
             name = "luasnip";
           }
           # Adds other completion capabilites.
           #  nvim-cmp does not ship with all sources by default. They are split
           #  into multiple repos for maintenance purposes.
+          # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp.html
           {
             name = "nvim_lsp";
           }
+          # https://nix-community.github.io/nixvim/plugins/cmp-path.html
           {
             name = "path";
           }


### PR DESCRIPTION
Since we have `plugins.cmp.sources` as a Nix list, the plugins listed there will be added as dependencies automatically. Therefore, it's redundant to additionally `plugins.<...>.enable = true` them.