### PR TITLE
chore: remove jsregexp from extraPackages and conform.neovim adjustment

### DIFF
--- a/plugins/conform.nix
+++ b/plugins/conform.nix
@@ -30,9 +30,13 @@
         # Conform can also run multiple formatters sequentially
         # python = [ "isort "black" ];
         #
-        # You can use a sublist to tell conform to run *until* a formatter
+        # You can use an attribute set and stop_after_first option to tell conform to run *until* a formatter
         # is found
-        # javascript = [ [ "prettierd" "prettier" ] ];
+        # javascript = {
+        #    __unkeyed-1 = "prettierd";
+        #    __unkeyed-2 = "prettier";
+        #    stop_after_first = true;
+        # };
       };
     };
 

--- a/plugins/nvim-cmp.nix
+++ b/plugins/nvim-cmp.nix
@@ -26,13 +26,6 @@
     #   enable = true;
     # };
 
-    # TODO: Waiting on this bug to be fixed https://github.com/NixOS/nixpkgs/issues/306367
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extralua#extraluapackages
-    extraLuaPackages = ps: [
-      # Required by luasnip
-      ps.jsregexp
-    ];
-
     # Autocompletion
     # See `:help cmp`
     # https://nix-community.github.io/nixvim/plugins/cmp/index.html


### PR DESCRIPTION
It's fixed and shipped within luasnip:

Ref: https://github.com/NixOS/nixpkgs/issues/306367#issuecomment-2323878756

This change is related to the package definition in the Nixpkgs repository: https://github.com/NixOS/nixpkgs/blob/12228ff1752d7b7624a54e9c1af4b222b3c1073b/pkgs/development/lua-modules/generated-packages.nix#L2153C27-L2153C40