### PR TITLE
fix(lsp): correct(ly pair) braces in the commented-out code

### DIFF
--- a/plugins/lsp.nix
+++ b/plugins/lsp.nix
@@ -103,8 +103,9 @@
               callSnippet = "Replace";
             };
             #diagnostics = {
-            #  disable = {
-            #    "missing-fields";
+            #  disable = [
+            #    "missing-fields"
+            #  ];
             #};
           };
         };


### PR DESCRIPTION
1. `lsp.servers.lua-ls.settings.diagnostics.disable` takes a list
2. an ending brace was missing