### PR TITLE
Move imports of plugins inside the nixvim option

### DIFF
--- a/nixvim.nix
+++ b/nixvim.nix
@@ -1,122 +1,128 @@
-{ pkgs, inputs, ... }: {
+{
+  pkgs,
+  inputs,
+  ...
+}: {
   imports = [
-    # NOTE: The first thing you will want to do is uncommented on of the three imports below
-    # depending on which module you chose to use to install Nixvim.
-    #
-    # Uncomment if you are using the home-manager module
-    #inputs.nixvim.homeManagerModules.nixvim
-    # Uncomment if you are using the nixos module
-    #inputs.nixvim.nixosModules.nixvim
-    # Uncomment if you are using the nix-darwin module
-    #inputs.nixvim.nixDarwinModules.nixvim
-
-    # Plugins
-    ./plugins/gitsigns.nix
-    ./plugins/which-key.nix
-    ./plugins/telescope.nix
-    ./plugins/lsp.nix
-    ./plugins/conform.nix
-    ./plugins/nvim-cmp.nix
-    ./plugins/todo-comments.nix
-    ./plugins/mini.nix
-    ./plugins/treesitter.nix
-
-    # NOTE: Add/Configure additional plugins for Kickstart.nixvim
-    #
-    #  Here are some example plugins that I've included in the Kickstart repository.
-    #  Uncomment any of the lines below to enable them (you will need to restart nvim).
-    #
-    # ./plugins/kickstart/plugins/debug.nix
-    # ./plugins/kickstart/plugins/indent-blankline.nix
-    # ./plugins/kickstart/plugins/lint.nix
-    # ./plugins/kickstart/plugins/autopairs.nix
-    # ./plugins/kickstart/plugins/neo-tree.nix
-    #
-    # NOTE: Configure your own plugins `see https://nix-community.github.io/nixvim/`
-    # Add your plugins to ./plugins/custom/plugins and import them below
+      # NOTE: The first thing you will want to do is uncommented on of the three imports below
+      # depending on which module you chose to use to install Nixvim.
+      #
+      # Uncomment if you are using the home-manager module
+      #inputs.nixvim.homeManagerModules.nixvim
+      # Uncomment if you are using the nixos module
+      #inputs.nixvim.nixosModules.nixvim
+      # Uncomment if you are using the nix-darwin module
+      #inputs.nixvim.nixDarwinModules.nixvim
   ];
 
-  /*
-  =====================================================================
-  ==================== READ THIS BEFORE CONTINUING ====================
-  =====================================================================
-  ========                                    .-----.          ========
-  ========         .----------------------.   | === |          ========
-  ========         |.-""""""""""""""""""-.|   |-----|          ========
-  ========         ||                    ||   | === |          ========
-  ========         ||  KICKSTART.NIXVIM  ||   |-----|          ========
-  ========         ||                    ||   | === |          ========
-  ========         ||                    ||   |-----|          ========
-  ========         ||:Tutor              ||   |:::::|          ========
-  ========         |'-..................-'|   |____o|          ========
-  ========         `"")----------------(""`   ___________      ========
-  ========        /::::::::::|  |::::::::::\  \ no mouse \     ========
-  ========       /:::========|  |==hjkl==:::\  \ required \    ========
-  ========      '""""""""""""'  '""""""""""""'  '""""""""""'   ========
-  ========                                                     ========
-  =====================================================================
-  =====================================================================
-
-  What is Kickstart.nixvim?
-
-    Kickstart.nixvim is a starting point for your own configuration.
-      The goal is that you can read every line of code, top-to-bottom, understand
-      what your configuration is doing, and modify it to suit your needs.
-
-      Once you've done that, you can start exploring, configuring and tinkering to
-      make Neovim your own!
-
-      If you don't know anything about Nixvim, Nix or Lua, I recommend taking some time to read through.
-        - https://nix-community.github.io/nixvim/
-        - https://learnxinyminutes.com/docs/nix/
-        - https://learnxinyminutes.com/docs/lua/
-
-  Kickstart.nixvim Guide:
-
-    TODO: The very first thing you should do is to run the command `:Tutor` in Neovim.
-
-      If you don't know what this means, type the following:
-        - <escape key>
-        - :
-        - Tutor
-        - <enter key>
-
-      (If you already know the Neovim basics, you can skip this step.)
-
-    Once you've completed that, you can continue working through **AND READING** the rest
-    of the nixvim.nix.
-
-    Next, run AND READ `:help`.
-      This will open up a help window with some basic information
-      about reading, navigating and searching the builtin help documentation.
-
-      This should be the first place you go to look when you're stuck or confused
-      with something. It's one of my favorite Neovim features.
-
-      MOST IMPORTANTLY, we provide a keymap "<space>sh" to [s]earch the [h]elp documentation,
-      which is very useful when you're not exactly sure of what you're looking for.
-
-    I have left several `:help X` comments throughout the nixvim.nix and the plugin .nix files
-      These are hints about where to find more information about the relevant settings,
-      plugins or Neovim features used in Kickstart.nixvim.
-
-     NOTE: Look for lines like this
-
-      Throughout the file. These are for you, the reader, to help you understand what is happening.
-      Feel free to delete them once you know what you're doing, but they should serve as a guide
-      for when you are first encountering a few different constructs in your Nixvim Neovim config.
-
-  If you experience any errors while trying to install kickstart, run `:checkhealth` for more info.
-
-  I hope you enjoy your Neovim journey,
-  - JMartJonesy
-
-  P.S. You can delete this when you're done too. It's your config now! :)
-  */
   programs.nixvim = {
     enable = true;
     defaultEditor = true;
 
+    imports = [
+      # Plugins
+      ./plugins/gitsigns.nix
+      ./plugins/which-key.nix
+      ./plugins/telescope.nix
+      ./plugins/lsp.nix
+      ./plugins/conform.nix
+      ./plugins/nvim-cmp.nix
+      ./plugins/todo-comments.nix
+      ./plugins/mini.nix
+      ./plugins/treesitter.nix
+
+      # NOTE: Add/Configure additional plugins for Kickstart.nixvim
+      #
+      #  Here are some example plugins that I've included in the Kickstart repository.
+      #  Uncomment any of the lines below to enable them (you will need to restart nvim).
+      #
+      # ./plugins/kickstart/plugins/debug.nix
+      # ./plugins/kickstart/plugins/indent-blankline.nix
+      # ./plugins/kickstart/plugins/lint.nix
+      # ./plugins/kickstart/plugins/autopairs.nix
+      # ./plugins/kickstart/plugins/neo-tree.nix
+      #
+      # NOTE: Configure your own plugins `see https://nix-community.github.io/nixvim/`
+      # Add your plugins to ./plugins/custom/plugins and import them below
+    ];
+
+    /*
+    =====================================================================
+    ==================== READ THIS BEFORE CONTINUING ====================
+    =====================================================================
+    ========                                    .-----.          ========
+    ========         .----------------------.   | === |          ========
+    ========         |.-""""""""""""""""""-.|   |-----|          ========
+    ========         ||                    ||   | === |          ========
+    ========         ||  KICKSTART.NIXVIM  ||   |-----|          ========
+    ========         ||                    ||   | === |          ========
+    ========         ||                    ||   |-----|          ========
+    ========         ||:Tutor              ||   |:::::|          ========
+    ========         |'-..................-'|   |____o|          ========
+    ========         `"")----------------(""`   ___________      ========
+    ========        /::::::::::|  |::::::::::\  \ no mouse \     ========
+    ========       /:::========|  |==hjkl==:::\  \ required \    ========
+    ========      '""""""""""""'  '""""""""""""'  '""""""""""'   ========
+    ========                                                     ========
+    =====================================================================
+    =====================================================================
+
+    What is Kickstart.nixvim?
+
+      Kickstart.nixvim is a starting point for your own configuration.
+        The goal is that you can read every line of code, top-to-bottom, understand
+        what your configuration is doing, and modify it to suit your needs.
+
+        Once you've done that, you can start exploring, configuring and tinkering to
+        make Neovim your own!
+
+        If you don't know anything about Nixvim, Nix or Lua, I recommend taking some time to read through.
+          - https://nix-community.github.io/nixvim/
+          - https://learnxinyminutes.com/docs/nix/
+          - https://learnxinyminutes.com/docs/lua/
+
+    Kickstart.nixvim Guide:
+
+      TODO: The very first thing you should do is to run the command `:Tutor` in Neovim.
+
+        If you don't know what this means, type the following:
+          - <escape key>
+          - :
+          - Tutor
+          - <enter key>
+
+        (If you already know the Neovim basics, you can skip this step.)
+
+      Once you've completed that, you can continue working through **AND READING** the rest
+      of the nixvim.nix.
+
+      Next, run AND READ `:help`.
+        This will open up a help window with some basic information
+        about reading, navigating and searching the builtin help documentation.
+
+        This should be the first place you go to look when you're stuck or confused
+        with something. It's one of my favorite Neovim features.
+
+        MOST IMPORTANTLY, we provide a keymap "<space>sh" to [s]earch the [h]elp documentation,
+        which is very useful when you're not exactly sure of what you're looking for.
+
+      I have left several `:help X` comments throughout the nixvim.nix and the plugin .nix files
+        These are hints about where to find more information about the relevant settings,
+        plugins or Neovim features used in Kickstart.nixvim.
+
+       NOTE: Look for lines like this
+
+        Throughout the file. These are for you, the reader, to help you understand what is happening.
+        Feel free to delete them once you know what you're doing, but they should serve as a guide
+        for when you are first encountering a few different constructs in your Nixvim Neovim config.
+
+    If you experience any errors while trying to install kickstart, run `:checkhealth` for more info.
+
+    I hope you enjoy your Neovim journey,
+    - JMartJonesy
+
+    P.S. You can delete this when you're done too. It's your config now! :)
+    */
     # You can easily change to a different colorscheme.
     # Add your colorscheme here and enable it.
     # Don't forget to disable the colorschemes you arent using

--- a/plugins/conform.nix
+++ b/plugins/conform.nix
@@ -1,57 +1,55 @@
 {pkgs, ...}: {
-  programs.nixvim = {
-    # Dependencies
-    #
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraplugins#extrapackages
-    extraPackages = with pkgs; [
-      # Used to format Lua code
-      stylua
-    ];
+  # Dependencies
+  #
+  # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraplugins#extrapackages
+  extraPackages = with pkgs; [
+    # Used to format Lua code
+    stylua
+  ];
 
-    # Autoformat
-    # https://nix-community.github.io/nixvim/plugins/conform-nvim.html
-    plugins.conform-nvim = {
-      enable = true;
-      settings = {
-        notify_on_error = false;
-        format_on_save = ''
-          function(bufnr)
-            -- Disable "format_on_save lsp_fallback" for lanuages that don't
-            -- have a well standardized coding style. You can add additional
-            -- lanuages here or re-enable it for the disabled ones.
-            local disable_filetypes = { c = true, cpp = true }
-            return {
-              timeout_ms = 500,
-              lsp_fallback = not disable_filetypes[vim.bo[bufnr].filetype]
-            }
-          end
-        '';
-        formatters_by_ft = {
-          lua = ["stylua"];
-          # Conform can also run multiple formatters sequentially
-          # python = [ "isort "black" ];
-          #
-          # You can use a sublist to tell conform to run *until* a formatter
-          # is found
-          # javascript = [ [ "prettierd" "prettier" ] ];
-        };
+  # Autoformat
+  # https://nix-community.github.io/nixvim/plugins/conform-nvim.html
+  plugins.conform-nvim = {
+    enable = true;
+    settings = {
+      notify_on_error = false;
+      format_on_save = ''
+        function(bufnr)
+          -- Disable "format_on_save lsp_fallback" for lanuages that don't
+          -- have a well standardized coding style. You can add additional
+          -- lanuages here or re-enable it for the disabled ones.
+          local disable_filetypes = { c = true, cpp = true }
+          return {
+            timeout_ms = 500,
+            lsp_fallback = not disable_filetypes[vim.bo[bufnr].filetype]
+          }
+        end
+      '';
+      formatters_by_ft = {
+        lua = ["stylua"];
+        # Conform can also run multiple formatters sequentially
+        # python = [ "isort "black" ];
+        #
+        # You can use a sublist to tell conform to run *until* a formatter
+        # is found
+        # javascript = [ [ "prettierd" "prettier" ] ];
       };
     };
-
-    # https://nix-community.github.io/nixvim/keymaps/index.html
-    keymaps = [
-      {
-        mode = "";
-        key = "<leader>f";
-        action.__raw = ''
-          function()
-            require('conform').format { async = true, lsp_fallback = true }
-          end
-        '';
-        options = {
-          desc = "[F]ormat buffer";
-        };
-      }
-    ];
   };
+
+  # https://nix-community.github.io/nixvim/keymaps/index.html
+  keymaps = [
+    {
+      mode = "";
+      key = "<leader>f";
+      action.__raw = ''
+        function()
+          require('conform').format { async = true, lsp_fallback = true }
+        end
+      '';
+      options = {
+        desc = "[F]ormat buffer";
+      };
+    }
+  ];
 }

--- a/plugins/gitsigns.nix
+++ b/plugins/gitsigns.nix
@@ -1,222 +1,220 @@
 {
-  programs.nixvim = {
-    # Adds git related signs to the gutter, as well as utilities for managing changes
-    # See `:help gitsigns` to understand what the configuration keys do
-    # https://nix-community.github.io/nixvim/plugins/gitsigns/index.html
-    plugins.gitsigns = {
-      enable = true;
-      settings = {
-        signs = {
-          add = {text = "+";};
-          change = {text = "~";};
-          delete = {text = "_";};
-          topdelete = {text = "‾";};
-          changedelete = {text = "~";};
-        };
+  # Adds git related signs to the gutter, as well as utilities for managing changes
+  # See `:help gitsigns` to understand what the configuration keys do
+  # https://nix-community.github.io/nixvim/plugins/gitsigns/index.html
+  plugins.gitsigns = {
+    enable = true;
+    settings = {
+      signs = {
+        add = {text = "+";};
+        change = {text = "~";};
+        delete = {text = "_";};
+        topdelete = {text = "‾";};
+        changedelete = {text = "~";};
       };
     };
-
-    # NOTE: add gitsigns recommended keymaps if you are interested
-    # https://nix-community.github.io/nixvim/keymaps/index.html
-    keymaps = [
-      # Navigation
-      {
-        mode = "n";
-        key = "]c";
-        action.__raw = ''
-          function()
-            if vim.wo.diff then
-              vim.cmd.normal { ']c', bang = true }
-            else
-              require('gitsigns').nav_hunk 'next'
-            end
-          end
-        '';
-        options = {
-          desc = "Jump to next git [c]hange";
-        };
-      }
-      {
-        mode = "n";
-        key = "[c";
-        action.__raw = ''
-          function()
-            if vim.wo.diff then
-              vim.cmd.normal { '[c', bang = true }
-            else
-              require('gitsigns').nav_hunk 'prev'
-            end
-          end
-        '';
-        options = {
-          desc = "Jump to previous git [c]hange";
-        };
-      }
-
-      # Actions
-      # visual mode
-      {
-        mode = "v";
-        key = "<leader>hs";
-        action.__raw = ''
-          function()
-            require('gitsigns').stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
-          end
-        '';
-        options = {
-          desc = "git [s]tage hunk";
-        };
-      }
-      {
-        mode = "v";
-        key = "<leader>hr";
-        action.__raw = ''
-          function()
-            require('gitsigns').reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
-          end
-        '';
-        options = {
-          desc = "git [r]eset hunk";
-        };
-      }
-      # normal mode
-      {
-        mode = "n";
-        key = "<leader>hs";
-        action.__raw = ''
-          function()
-            require('gitsigns').stage_hunk()
-          end
-        '';
-        options = {
-          desc = "git [s]tage hunk";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hr";
-        action.__raw = ''
-          function()
-            require('gitsigns').reset_hunk()
-          end
-        '';
-        options = {
-          desc = "git [r]eset hunk";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hS";
-        action.__raw = ''
-          function()
-            require('gitsigns').stage_buffer()
-          end
-        '';
-        options = {
-          desc = "git [S]tage buffer";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hu";
-        # `undo_stage_hunk` is deprecated. See https://github.com/nvim-lua/kickstart.nvim/issues/1319
-        #  Replacement `stage_hunk` was accidentally merged. See https://github.com/nvim-lua/kickstart.nvim/pull/1321#issuecomment-2664265962
-        action.__raw = ''
-          function()
-            require('gitsigns').undo_stage_hunk()
-          end
-        '';
-        options = {
-          desc = "git [u]ndo stage hunk";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hR";
-        action.__raw = ''
-          function()
-            require('gitsigns').reset_buffer()
-          end
-        '';
-        options = {
-          desc = "git [R]eset buffer";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hp";
-        action.__raw = ''
-          function()
-            require('gitsigns').preview_hunk()
-          end
-        '';
-        options = {
-          desc = "git [p]review hunk";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hb";
-        action.__raw = ''
-          function()
-            require('gitsigns').blame_line()
-          end
-        '';
-        options = {
-          desc = "git [b]lame line";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hd";
-        action.__raw = ''
-          function()
-            require('gitsigns').diffthis()
-          end
-        '';
-        options = {
-          desc = "git [d]iff against index";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>hD";
-        action.__raw = ''
-          function()
-            require('gitsigns').diffthis '@'
-          end
-        '';
-        options = {
-          desc = "git [D]iff against last commit";
-        };
-      }
-      # Toggles
-      {
-        mode = "n";
-        key = "<leader>tb";
-        action.__raw = ''
-          function()
-            require('gitsigns').toggle_current_line_blame()
-          end
-        '';
-        options = {
-          desc = "[T]oggle git show [b]lame line";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>tD";
-        # `toggle_deleted` is deprecated. See https://github.com/nvim-lua/kickstart.nvim/issues/1319
-        #  Replacement `preview_hunk_inline` was accidentally merged. See https://github.com/nvim-lua/kickstart.nvim/pull/1321#issuecomment-2664265962
-        action.__raw = ''
-          function()
-            require('gitsigns').toggle_deleted()
-          end
-        '';
-        options = {
-          desc = "[T]oggle git show [D]eleted";
-        };
-      }
-    ];
   };
+
+  # NOTE: add gitsigns recommended keymaps if you are interested
+  # https://nix-community.github.io/nixvim/keymaps/index.html
+  keymaps = [
+    # Navigation
+    {
+      mode = "n";
+      key = "]c";
+      action.__raw = ''
+        function()
+          if vim.wo.diff then
+            vim.cmd.normal { ']c', bang = true }
+          else
+            require('gitsigns').nav_hunk 'next'
+          end
+        end
+      '';
+      options = {
+        desc = "Jump to next git [c]hange";
+      };
+    }
+    {
+      mode = "n";
+      key = "[c";
+      action.__raw = ''
+        function()
+          if vim.wo.diff then
+            vim.cmd.normal { '[c', bang = true }
+          else
+            require('gitsigns').nav_hunk 'prev'
+          end
+        end
+      '';
+      options = {
+        desc = "Jump to previous git [c]hange";
+      };
+    }
+
+    # Actions
+    # visual mode
+    {
+      mode = "v";
+      key = "<leader>hs";
+      action.__raw = ''
+        function()
+          require('gitsigns').stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
+        end
+      '';
+      options = {
+        desc = "git [s]tage hunk";
+      };
+    }
+    {
+      mode = "v";
+      key = "<leader>hr";
+      action.__raw = ''
+        function()
+          require('gitsigns').reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
+        end
+      '';
+      options = {
+        desc = "git [r]eset hunk";
+      };
+    }
+    # normal mode
+    {
+      mode = "n";
+      key = "<leader>hs";
+      action.__raw = ''
+        function()
+          require('gitsigns').stage_hunk()
+        end
+      '';
+      options = {
+        desc = "git [s]tage hunk";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hr";
+      action.__raw = ''
+        function()
+          require('gitsigns').reset_hunk()
+        end
+      '';
+      options = {
+        desc = "git [r]eset hunk";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hS";
+      action.__raw = ''
+        function()
+          require('gitsigns').stage_buffer()
+        end
+      '';
+      options = {
+        desc = "git [S]tage buffer";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hu";
+      # `undo_stage_hunk` is deprecated. See https://github.com/nvim-lua/kickstart.nvim/issues/1319
+      #  Replacement `stage_hunk` was accidentally merged. See https://github.com/nvim-lua/kickstart.nvim/pull/1321#issuecomment-2664265962
+      action.__raw = ''
+        function()
+          require('gitsigns').undo_stage_hunk()
+        end
+      '';
+      options = {
+        desc = "git [u]ndo stage hunk";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hR";
+      action.__raw = ''
+        function()
+          require('gitsigns').reset_buffer()
+        end
+      '';
+      options = {
+        desc = "git [R]eset buffer";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hp";
+      action.__raw = ''
+        function()
+          require('gitsigns').preview_hunk()
+        end
+      '';
+      options = {
+        desc = "git [p]review hunk";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hb";
+      action.__raw = ''
+        function()
+          require('gitsigns').blame_line()
+        end
+      '';
+      options = {
+        desc = "git [b]lame line";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hd";
+      action.__raw = ''
+        function()
+          require('gitsigns').diffthis()
+        end
+      '';
+      options = {
+        desc = "git [d]iff against index";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>hD";
+      action.__raw = ''
+        function()
+          require('gitsigns').diffthis '@'
+        end
+      '';
+      options = {
+        desc = "git [D]iff against last commit";
+      };
+    }
+    # Toggles
+    {
+      mode = "n";
+      key = "<leader>tb";
+      action.__raw = ''
+        function()
+          require('gitsigns').toggle_current_line_blame()
+        end
+      '';
+      options = {
+        desc = "[T]oggle git show [b]lame line";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>tD";
+      # `toggle_deleted` is deprecated. See https://github.com/nvim-lua/kickstart.nvim/issues/1319
+      #  Replacement `preview_hunk_inline` was accidentally merged. See https://github.com/nvim-lua/kickstart.nvim/pull/1321#issuecomment-2664265962
+      action.__raw = ''
+        function()
+          require('gitsigns').toggle_deleted()
+        end
+      '';
+      options = {
+        desc = "[T]oggle git show [D]eleted";
+      };
+    }
+  ];
 }

--- a/plugins/kickstart/plugins/autopairs.nix
+++ b/plugins/kickstart/plugins/autopairs.nix
@@ -1,15 +1,13 @@
 {
   # Inserts matching pairs of parens, brackets, etc.
   # https://nix-community.github.io/nixvim/plugins/nvim-autopairs/index.html
-  programs.nixvim = {
-    plugins.nvim-autopairs = {
-      enable = true;
-    };
-
-    # If you want to automatically add `(` after selecting a function or method
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraconfiglua#extraconfiglua
-    extraConfigLua = ''
-      require('cmp').event:on('confirm_done', require('nvim-autopairs.completion.cmp').on_confirm_done())
-    '';
+  plugins.nvim-autopairs = {
+    enable = true;
   };
+
+  # If you want to automatically add `(` after selecting a function or method
+  # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraconfiglua#extraconfiglua
+  extraConfigLua = ''
+    require('cmp').event:on('confirm_done', require('nvim-autopairs.completion.cmp').on_confirm_done())
+  '';
 }

--- a/plugins/kickstart/plugins/debug.nix
+++ b/plugins/kickstart/plugins/debug.nix
@@ -1,146 +1,144 @@
 {
-  programs.nixvim = {
-    # Shows how to use the DAP plugin to debug your code.
-    #
-    # Primarily focused on configuring the debugger for Go, but can
-    # be extended to other languages as well. That's why it's called
-    # kickstart.nixvim and not kitchen-sink.nixvim ;)
-    # https://nix-community.github.io/nixvim/plugins/dap/index.html
-    plugins.dap = {
-      enable = true;
-    };
+  # Shows how to use the DAP plugin to debug your code.
+  #
+  # Primarily focused on configuring the debugger for Go, but can
+  # be extended to other languages as well. That's why it's called
+  # kickstart.nixvim and not kitchen-sink.nixvim ;)
+  # https://nix-community.github.io/nixvim/plugins/dap/index.html
+  plugins.dap = {
+    enable = true;
+  };
 
-    # Creates a beautiful debugger UI
-    plugins.dap-ui = {
-      enable = true;
+  # Creates a beautiful debugger UI
+  plugins.dap-ui = {
+    enable = true;
 
-      # Set icons to characters that are more likely to work in every terminal.
-      # Feel free to remove or use ones that you like more! :)
-      # Don't feel like these are good choices.
-      settings = {
+    # Set icons to characters that are more likely to work in every terminal.
+    # Feel free to remove or use ones that you like more! :)
+    # Don't feel like these are good choices.
+    settings = {
+      icons = {
+        expanded = "▾";
+        collapsed = "▸";
+        current_frame = "*";
+      };
+
+      controls = {
         icons = {
-          expanded = "▾";
-          collapsed = "▸";
-          current_frame = "*";
-        };
-
-        controls = {
-          icons = {
-            pause = "⏸";
-            play = "▶";
-            step_into = "⏎";
-            step_over = "⏭";
-            step_out = "⏮";
-            step_back = "b";
-            run_last = "▶▶";
-            terminate = "⏹";
-            disconnect = "⏏";
-          };
+          pause = "⏸";
+          play = "▶";
+          step_into = "⏎";
+          step_over = "⏭";
+          step_out = "⏮";
+          step_back = "b";
+          run_last = "▶▶";
+          terminate = "⏹";
+          disconnect = "⏏";
         };
       };
     };
-
-    # Add your own debuggers here
-    plugins.dap-go = {
-      enable = true;
-    };
-
-    # https://nix-community.github.io/nixvim/keymaps/index.html
-    keymaps = [
-      # Basic debugging keymaps, feel free to change to your liking!
-      {
-        mode = "n";
-        key = "<F5>";
-        action.__raw = ''
-          function()
-            require('dap').continue()
-          end
-        '';
-        options = {
-          desc = "Debug: Start/Continue";
-        };
-      }
-      {
-        mode = "n";
-        key = "<F1>";
-        action.__raw = ''
-          function()
-            require('dap').step_into()
-          end
-        '';
-        options = {
-          desc = "Debug: Step Into";
-        };
-      }
-      {
-        mode = "n";
-        key = "<F2>";
-        action.__raw = ''
-          function()
-            require('dap').step_over()
-          end
-        '';
-        options = {
-          desc = "Debug: Step Over";
-        };
-      }
-      {
-        mode = "n";
-        key = "<F3>";
-        action.__raw = ''
-          function()
-            require('dap').step_out()
-          end
-        '';
-        options = {
-          desc = "Debug: Step Out";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>b";
-        action.__raw = ''
-          function()
-            require('dap').toggle_breakpoint()
-          end
-        '';
-        options = {
-          desc = "Debug: Toggle Breakpoint";
-        };
-      }
-      {
-        mode = "n";
-        key = "<leader>B";
-        action.__raw = ''
-          function()
-            require('dap').set_breakpoint(vim.fn.input 'Breakpoint condition: ')
-          end
-        '';
-        options = {
-          desc = "Debug: Set Breakpoint";
-        };
-      }
-      # Toggle to see last session result. Without this, you can't see session output
-      # in case of unhandled exception.
-      {
-        mode = "n";
-        key = "<F7>";
-        action.__raw = ''
-          function()
-            require('dapui').toggle()
-          end
-        '';
-        options = {
-          desc = "Debug: See last session result.";
-        };
-      }
-    ];
-
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraconfiglua#extraconfiglua
-    extraConfigLua = ''
-      require('dap').listeners.after.event_initialized['dapui_config'] = require('dapui').open
-      require('dap').listeners.before.event_terminated['dapui_config'] = require('dapui').close
-      require('dap').listeners.before.event_exited['dapui_config'] = require('dapui').close
-    '';
   };
+
+  # Add your own debuggers here
+  plugins.dap-go = {
+    enable = true;
+  };
+
+  # https://nix-community.github.io/nixvim/keymaps/index.html
+  keymaps = [
+    # Basic debugging keymaps, feel free to change to your liking!
+    {
+      mode = "n";
+      key = "<F5>";
+      action.__raw = ''
+        function()
+          require('dap').continue()
+        end
+      '';
+      options = {
+        desc = "Debug: Start/Continue";
+      };
+    }
+    {
+      mode = "n";
+      key = "<F1>";
+      action.__raw = ''
+        function()
+          require('dap').step_into()
+        end
+      '';
+      options = {
+        desc = "Debug: Step Into";
+      };
+    }
+    {
+      mode = "n";
+      key = "<F2>";
+      action.__raw = ''
+        function()
+          require('dap').step_over()
+        end
+      '';
+      options = {
+        desc = "Debug: Step Over";
+      };
+    }
+    {
+      mode = "n";
+      key = "<F3>";
+      action.__raw = ''
+        function()
+          require('dap').step_out()
+        end
+      '';
+      options = {
+        desc = "Debug: Step Out";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>b";
+      action.__raw = ''
+        function()
+          require('dap').toggle_breakpoint()
+        end
+      '';
+      options = {
+        desc = "Debug: Toggle Breakpoint";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>B";
+      action.__raw = ''
+        function()
+          require('dap').set_breakpoint(vim.fn.input 'Breakpoint condition: ')
+        end
+      '';
+      options = {
+        desc = "Debug: Set Breakpoint";
+      };
+    }
+    # Toggle to see last session result. Without this, you can't see session output
+    # in case of unhandled exception.
+    {
+      mode = "n";
+      key = "<F7>";
+      action.__raw = ''
+        function()
+          require('dapui').toggle()
+        end
+      '';
+      options = {
+        desc = "Debug: See last session result.";
+      };
+    }
+  ];
+
+  # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraconfiglua#extraconfiglua
+  extraConfigLua = ''
+    require('dap').listeners.after.event_initialized['dapui_config'] = require('dapui').open
+    require('dap').listeners.before.event_terminated['dapui_config'] = require('dapui').close
+    require('dap').listeners.before.event_exited['dapui_config'] = require('dapui').close
+  '';
 }

--- a/plugins/kickstart/plugins/indent-blankline.nix
+++ b/plugins/kickstart/plugins/indent-blankline.nix
@@ -1,10 +1,8 @@
 {
-  programs.nixvim = {
-    # Add indentation guides even on blank lines
-    # For configuration see `:help ibl`
-    # https://nix-community.github.io/nixvim/plugins/indent-blankline/index.html
-    plugins.indent-blankline = {
-      enable = true;
-    };
+  # Add indentation guides even on blank lines
+  # For configuration see `:help ibl`
+  # https://nix-community.github.io/nixvim/plugins/indent-blankline/index.html
+  plugins.indent-blankline = {
+    enable = true;
   };
 }

--- a/plugins/kickstart/plugins/lint.nix
+++ b/plugins/kickstart/plugins/lint.nix
@@ -1,50 +1,48 @@
 {
-  programs.nixvim = {
-    # Linting
-    # https://nix-community.github.io/nixvim/plugins/lint/index.html
-    plugins.lint = {
-      enable = true;
+  # Linting
+  # https://nix-community.github.io/nixvim/plugins/lint/index.html
+  plugins.lint = {
+    enable = true;
 
-      # NOTE: Enabling these will cause errors unless these tools are installed
-      lintersByFt = {
-        nix = ["nix"];
-        markdown = [
-          "markdownlint"
-          #vale
-        ];
-        #clojure = ["clj-kondo"];
-        #dockerfile = ["hadolint"];
-        #inko = ["inko"];
-        #janet = ["janet"];
-        #json = ["jsonlint"];
-        #rst = ["vale"];
-        #ruby = ["ruby"];
-        #terraform = ["tflint"];
-        #text = ["vale"];
-      };
-
-      # Create autocommand which carries out the actual linting
-      # on the specified events.
-      autoCmd = {
-        callback.__raw = ''
-          function()
-            require('lint').try_lint()
-          end
-        '';
-        group = "lint";
-        event = [
-          "BufEnter"
-          "BufWritePost"
-          "InsertLeave"
-        ];
-      };
+    # NOTE: Enabling these will cause errors unless these tools are installed
+    lintersByFt = {
+      nix = ["nix"];
+      markdown = [
+        "markdownlint"
+        #vale
+      ];
+      #clojure = ["clj-kondo"];
+      #dockerfile = ["hadolint"];
+      #inko = ["inko"];
+      #janet = ["janet"];
+      #json = ["jsonlint"];
+      #rst = ["vale"];
+      #ruby = ["ruby"];
+      #terraform = ["tflint"];
+      #text = ["vale"];
     };
 
-    # https://nix-community.github.io/nixvim/NeovimOptions/autoGroups/index.html
-    autoGroups = {
-      lint = {
-        clear = true;
-      };
+    # Create autocommand which carries out the actual linting
+    # on the specified events.
+    autoCmd = {
+      callback.__raw = ''
+        function()
+          require('lint').try_lint()
+        end
+      '';
+      group = "lint";
+      event = [
+        "BufEnter"
+        "BufWritePost"
+        "InsertLeave"
+      ];
+    };
+  };
+
+  # https://nix-community.github.io/nixvim/NeovimOptions/autoGroups/index.html
+  autoGroups = {
+    lint = {
+      clear = true;
     };
   };
 }

--- a/plugins/kickstart/plugins/neo-tree.nix
+++ b/plugins/kickstart/plugins/neo-tree.nix
@@ -1,28 +1,26 @@
 {
-  programs.nixvim = {
-    # Neo-tree is a Neovim plugin to browse the file system
-    # https://nix-community.github.io/nixvim/plugins/neo-tree/index.html?highlight=neo-tree#pluginsneo-treepackage
-    plugins.neo-tree = {
-      enable = true;
+  # Neo-tree is a Neovim plugin to browse the file system
+  # https://nix-community.github.io/nixvim/plugins/neo-tree/index.html?highlight=neo-tree#pluginsneo-treepackage
+  plugins.neo-tree = {
+    enable = true;
 
-      filesystem = {
-        window = {
-          mappings = {
-            "\\" = "close_window";
-          };
+    filesystem = {
+      window = {
+        mappings = {
+          "\\" = "close_window";
         };
       };
     };
-
-    # https://nix-community.github.io/nixvim/keymaps/index.html
-    keymaps = [
-      {
-        key = "\\";
-        action = "<cmd>Neotree reveal<cr>";
-        options = {
-          desc = "NeoTree reveal";
-        };
-      }
-    ];
   };
+
+  # https://nix-community.github.io/nixvim/keymaps/index.html
+  keymaps = [
+    {
+      key = "\\";
+      action = "<cmd>Neotree reveal<cr>";
+      options = {
+        desc = "NeoTree reveal";
+      };
+    }
+  ];
 }

--- a/plugins/lsp.nix
+++ b/plugins/lsp.nix
@@ -1,275 +1,273 @@
 {pkgs, ...}: {
-  programs.nixvim = {
-    # Dependencies
-    # { 'Bilal2453/luvit-meta', lazy = true },
-    #
-    #
-    # Allows extra capabilities providied by nvim-cmp
-    # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp.html
-    plugins.cmp-nvim-lsp = {
-      enable = true;
-    };
+  # Dependencies
+  # { 'Bilal2453/luvit-meta', lazy = true },
+  #
+  #
+  # Allows extra capabilities providied by nvim-cmp
+  # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp.html
+  plugins.cmp-nvim-lsp = {
+    enable = true;
+  };
 
-    # Useful status updates for LSP.
-    # https://nix-community.github.io/nixvim/plugins/fidget/index.html
-    plugins.fidget = {
-      enable = true;
-    };
+  # Useful status updates for LSP.
+  # https://nix-community.github.io/nixvim/plugins/fidget/index.html
+  plugins.fidget = {
+    enable = true;
+  };
 
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraplugi#extraplugins
-    extraPlugins = with pkgs.vimPlugins; [
-      # NOTE: This is where you would add a vim plugin that is not implemented in Nixvim, also see extraConfigLuaPre below
+  # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraplugi#extraplugins
+  extraPlugins = with pkgs.vimPlugins; [
+    # NOTE: This is where you would add a vim plugin that is not implemented in Nixvim, also see extraConfigLuaPre below
+    #
+    # TODO: Add luvit-meta when Nixos package is added
+  ];
+
+  # https://nix-community.github.io/nixvim/NeovimOptions/autoGroups/index.html
+  autoGroups = {
+    "kickstart-lsp-attach" = {
+      clear = true;
+    };
+  };
+
+  # Brief aside: **What is LSP?**
+  #
+  # LSP is an initialism you've probably heard, but might not understand what it is.
+  #
+  # LSP stands for Language Server Protocol. It's a protocol that helps editors
+  # and language tooling communicate in a standardized fashion.
+  #
+  # In general, you have a "server" which is some tool built to understand a particular
+  # language (such as `gopls`, `lua_ls`, `rust_analyzer`, etc.). These Language Servers
+  # (sometimes called LSP servers, but that's kind of like ATM Machine) are standalone
+  # processes that communicate with some "client" - in this case, Neovim!
+  #
+  # LSP provides Neovim with features like:
+  #  - Go to definition
+  #  - Find references
+  #  - Autocompletion
+  #  - Symbol Search
+  #  - and more!
+  #
+  # Thus, Language Servers are external tools that must be installed separately from
+  # Neovim which are configured below in the `server` section.
+  #
+  # If you're wondering about lsp vs treesitter, you can check out the wonderfully
+  # and elegantly composed help section, `:help lsp-vs-treesitter`
+  #
+  # https://nix-community.github.io/nixvim/plugins/lsp/index.html
+  plugins.lsp = {
+    enable = true;
+
+    # Enable the following language servers
+    #  Feel free to add/remove any LSPs that you want here. They will automatically be installed.
+    #
+    #  Add any additional override configuration in the following tables. Available keys are:
+    #  - cmd: Override the default command used to start the server
+    #  - filetypes: Override the default list of associated filetypes for the server
+    #  - capabilities: Override fields in capabilities. Can be used to disable certain LSP features.
+    #  - settings: Override the default settings passed when initializing the server.
+    #        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
+    servers = {
+      # clangd = {
+      #   enable = true;
+      # };
+      # gopls = {
+      #   enable = true;
+      # };
+      # pyright = {
+      #   enable = true;
+      # };
+      # rust_analyzer = {
+      #   enable = true;
+      # };
+      # ...etc. See `https://nix-community.github.io/nixvim/plugins/lsp` for a list of pre-configured LSPs
       #
-      # TODO: Add luvit-meta when Nixos package is added
-    ];
-
-    # https://nix-community.github.io/nixvim/NeovimOptions/autoGroups/index.html
-    autoGroups = {
-      "kickstart-lsp-attach" = {
-        clear = true;
-      };
-    };
-
-    # Brief aside: **What is LSP?**
-    #
-    # LSP is an initialism you've probably heard, but might not understand what it is.
-    #
-    # LSP stands for Language Server Protocol. It's a protocol that helps editors
-    # and language tooling communicate in a standardized fashion.
-    #
-    # In general, you have a "server" which is some tool built to understand a particular
-    # language (such as `gopls`, `lua_ls`, `rust_analyzer`, etc.). These Language Servers
-    # (sometimes called LSP servers, but that's kind of like ATM Machine) are standalone
-    # processes that communicate with some "client" - in this case, Neovim!
-    #
-    # LSP provides Neovim with features like:
-    #  - Go to definition
-    #  - Find references
-    #  - Autocompletion
-    #  - Symbol Search
-    #  - and more!
-    #
-    # Thus, Language Servers are external tools that must be installed separately from
-    # Neovim which are configured below in the `server` section.
-    #
-    # If you're wondering about lsp vs treesitter, you can check out the wonderfully
-    # and elegantly composed help section, `:help lsp-vs-treesitter`
-    #
-    # https://nix-community.github.io/nixvim/plugins/lsp/index.html
-    plugins.lsp = {
-      enable = true;
-
-      # Enable the following language servers
-      #  Feel free to add/remove any LSPs that you want here. They will automatically be installed.
+      # Some languages (like typscript) have entire language plugins that can be useful:
+      #    `https://nix-community.github.io/nixvim/plugins/typescript-tools/index.html?highlight=typescript-tools#pluginstypescript-toolspackage`
       #
-      #  Add any additional override configuration in the following tables. Available keys are:
-      #  - cmd: Override the default command used to start the server
-      #  - filetypes: Override the default list of associated filetypes for the server
-      #  - capabilities: Override fields in capabilities. Can be used to disable certain LSP features.
-      #  - settings: Override the default settings passed when initializing the server.
-      #        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
-      servers = {
-        # clangd = {
-        #   enable = true;
-        # };
-        # gopls = {
-        #   enable = true;
-        # };
-        # pyright = {
-        #   enable = true;
-        # };
-        # rust_analyzer = {
-        #   enable = true;
-        # };
-        # ...etc. See `https://nix-community.github.io/nixvim/plugins/lsp` for a list of pre-configured LSPs
-        #
-        # Some languages (like typscript) have entire language plugins that can be useful:
-        #    `https://nix-community.github.io/nixvim/plugins/typescript-tools/index.html?highlight=typescript-tools#pluginstypescript-toolspackage`
-        #
-        # But for many setups the LSP (`tsserver`) will work just fine
-        # tsserver = {
-        #   enable = true;
-        # };
+      # But for many setups the LSP (`tsserver`) will work just fine
+      # tsserver = {
+      #   enable = true;
+      # };
 
-        lua_ls = {
-          enable = true;
+      lua_ls = {
+        enable = true;
 
-          # cmd = {
-          # };
-          # filetypes = {
-          # };
-          settings = {
-            completion = {
-              callSnippet = "Replace";
-            };
-            # diagnostics = {
-            #   disable = [
-            #     "missing-fields"
-            #   ];
-            # };
+        # cmd = {
+        # };
+        # filetypes = {
+        # };
+        settings = {
+          completion = {
+            callSnippet = "Replace";
           };
+          # diagnostics = {
+          #   disable = [
+          #     "missing-fields"
+          #   ];
+          # };
         };
       };
-
-      keymaps = {
-        # Diagnostic keymaps
-        diagnostic = {
-          "<leader>q" = {
-            mode = "n";
-            action = "setloclist";
-            desc = "Open diagnostic [Q]uickfix list";
-          };
-        };
-
-        extra = [
-          # Jump to the definition of the word under your cusor.
-          #  This is where a variable was first declared, or where a function is defined, etc.
-          #  To jump back, press <C-t>.
-          {
-            mode = "n";
-            key = "gd";
-            action.__raw = "require('telescope.builtin').lsp_definitions";
-            options = {
-              desc = "LSP: [G]oto [D]efinition";
-            };
-          }
-          # Find references for the word under your cursor.
-          {
-            mode = "n";
-            key = "gr";
-            action.__raw = "require('telescope.builtin').lsp_references";
-            options = {
-              desc = "LSP: [G]oto [R]eferences";
-            };
-          }
-          # Jump to the implementation of the word under your cursor.
-          #  Useful when your language has ways of declaring types without an actual implementation.
-          {
-            mode = "n";
-            key = "gI";
-            action.__raw = "require('telescope.builtin').lsp_implementations";
-            options = {
-              desc = "LSP: [G]oto [I]mplementation";
-            };
-          }
-          # Jump to the type of the word under your cursor.
-          #  Useful when you're not sure what type a variable is and you want to see
-          #  the definition of its *type*, not where it was *defined*.
-          {
-            mode = "n";
-            key = "<leader>D";
-            action.__raw = "require('telescope.builtin').lsp_type_definitions";
-            options = {
-              desc = "LSP: Type [D]efinition";
-            };
-          }
-          # Fuzzy find all the symbols in your current document.
-          #  Symbols are things like variables, functions, types, etc.
-          {
-            mode = "n";
-            key = "<leader>ds";
-            action.__raw = "require('telescope.builtin').lsp_document_symbols";
-            options = {
-              desc = "LSP: [D]ocument [S]ymbols";
-            };
-          }
-          # Fuzzy find all the symbols in your current workspace.
-          #  Similar to document symbols, except searches over your entire project.
-          {
-            mode = "n";
-            key = "<leader>ws";
-            action.__raw = "require('telescope.builtin').lsp_dynamic_workspace_symbols";
-            options = {
-              desc = "LSP: [W]orkspace [S]ymbols";
-            };
-          }
-        ];
-
-        lspBuf = {
-          # Rename the variable under your cursor.
-          #  Most Language Servers support renaming across files, etc.
-          "<leader>rn" = {
-            action = "rename";
-            desc = "LSP: [R]e[n]ame";
-          };
-          # Execute a code action, usually your cursor needs to be on top of an error
-          # or a suggestion from your LSP for this to activate.
-          "<leader>ca" = {
-            mode = ["n" "x"];
-            action = "code_action";
-            desc = "LSP: [C]ode [A]ction";
-          };
-          # WARN: This is not Goto Definition, this is Goto Declaration.
-          #  For example, in C this would take you to the header.
-          "gD" = {
-            action = "declaration";
-            desc = "LSP: [G]oto [D]eclaration";
-          };
-        };
-      };
-
-      # LSP servers and clients are able to communicate to each other what features they support.
-      #  By default, Neovim doesn't support everything that is in the LSP specification.
-      #  When you add nvim-cmp, luasnip, etc. Neovim now has *more* capabilities.
-      #  So, we create new capabilities with nvim cmp, and then broadcast that to the servers.
-      # NOTE: This is done automatically by Nixvim when enabling cmp-nvim-lsp below is an example if you did want to add new capabilities
-      #capabilities = ''
-      #  capabilities = vim.tbl_deep_extend('force', capabilities, require('cmp_nvim_lsp').default_capabilities())
-      #'';
-
-      # This function gets run when an LSP attaches to a particular buffer.
-      #   That is to say, every time a new file is opened that is associated with
-      #   an lsp (for example, opening `main.rs` is associated with `rust_analyzer`) this
-      #   function will be executred to configure the current buffer
-      # NOTE: This is an example of an attribute that takes raw lua
-      onAttach = ''
-        -- NOTE: Remember that Lua is a real programming language, and as such it is possible
-        -- to define small helper and utility functions so you don't have to repeat yourself.
-        --
-        -- In this case, we create a function that lets us more easily define mappings specific
-        -- for LSP related items. It sets the mode, buffer and description for us each time.
-        local map = function(keys, func, desc)
-          vim.keymap.set('n', keys, func, { buffer = bufnr, desc = 'LSP: ' .. desc })
-        end
-
-        -- The following two autocommands are used to highlight references of the
-        -- word under the cursor when your cursor rests there for a little while.
-        --    See `:help CursorHold` for information about when this is executed
-        --
-        -- When you move your cursor, the highlights will be cleared (the second autocommand).
-        if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_documentHighlight) then
-          local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = false })
-          vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
-            buffer = bufnr,
-            group = highlight_augroup,
-            callback = vim.lsp.buf.document_highlight,
-          })
-
-          vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
-            buffer = bufnr,
-            group = highlight_augroup,
-            callback = vim.lsp.buf.clear_references,
-          })
-
-          vim.api.nvim_create_autocmd('LspDetach', {
-            group = vim.api.nvim_create_augroup('kickstart-lsp-detach', { clear = true }),
-            callback = function(event2)
-              vim.lsp.buf.clear_references()
-              vim.api.nvim_clear_autocmds { group = 'kickstart-lsp-highlight', buffer = event2.buf }
-            end,
-          })
-        end
-
-        -- The following autocommand is used to enable inlay hints in your
-        -- code, if the language server you are using supports them
-        --
-        -- This may be unwanted, since they displace some of your code
-        if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
-          map('<leader>th', function()
-            vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled { bufnr = event.buf })
-          end, '[T]oggle Inlay [H]ints')
-        end
-      '';
     };
+
+    keymaps = {
+      # Diagnostic keymaps
+      diagnostic = {
+        "<leader>q" = {
+          mode = "n";
+          action = "setloclist";
+          desc = "Open diagnostic [Q]uickfix list";
+        };
+      };
+
+      extra = [
+        # Jump to the definition of the word under your cusor.
+        #  This is where a variable was first declared, or where a function is defined, etc.
+        #  To jump back, press <C-t>.
+        {
+          mode = "n";
+          key = "gd";
+          action.__raw = "require('telescope.builtin').lsp_definitions";
+          options = {
+            desc = "LSP: [G]oto [D]efinition";
+          };
+        }
+        # Find references for the word under your cursor.
+        {
+          mode = "n";
+          key = "gr";
+          action.__raw = "require('telescope.builtin').lsp_references";
+          options = {
+            desc = "LSP: [G]oto [R]eferences";
+          };
+        }
+        # Jump to the implementation of the word under your cursor.
+        #  Useful when your language has ways of declaring types without an actual implementation.
+        {
+          mode = "n";
+          key = "gI";
+          action.__raw = "require('telescope.builtin').lsp_implementations";
+          options = {
+            desc = "LSP: [G]oto [I]mplementation";
+          };
+        }
+        # Jump to the type of the word under your cursor.
+        #  Useful when you're not sure what type a variable is and you want to see
+        #  the definition of its *type*, not where it was *defined*.
+        {
+          mode = "n";
+          key = "<leader>D";
+          action.__raw = "require('telescope.builtin').lsp_type_definitions";
+          options = {
+            desc = "LSP: Type [D]efinition";
+          };
+        }
+        # Fuzzy find all the symbols in your current document.
+        #  Symbols are things like variables, functions, types, etc.
+        {
+          mode = "n";
+          key = "<leader>ds";
+          action.__raw = "require('telescope.builtin').lsp_document_symbols";
+          options = {
+            desc = "LSP: [D]ocument [S]ymbols";
+          };
+        }
+        # Fuzzy find all the symbols in your current workspace.
+        #  Similar to document symbols, except searches over your entire project.
+        {
+          mode = "n";
+          key = "<leader>ws";
+          action.__raw = "require('telescope.builtin').lsp_dynamic_workspace_symbols";
+          options = {
+            desc = "LSP: [W]orkspace [S]ymbols";
+          };
+        }
+      ];
+
+      lspBuf = {
+        # Rename the variable under your cursor.
+        #  Most Language Servers support renaming across files, etc.
+        "<leader>rn" = {
+          action = "rename";
+          desc = "LSP: [R]e[n]ame";
+        };
+        # Execute a code action, usually your cursor needs to be on top of an error
+        # or a suggestion from your LSP for this to activate.
+        "<leader>ca" = {
+          mode = ["n" "x"];
+          action = "code_action";
+          desc = "LSP: [C]ode [A]ction";
+        };
+        # WARN: This is not Goto Definition, this is Goto Declaration.
+        #  For example, in C this would take you to the header.
+        "gD" = {
+          action = "declaration";
+          desc = "LSP: [G]oto [D]eclaration";
+        };
+      };
+    };
+
+    # LSP servers and clients are able to communicate to each other what features they support.
+    #  By default, Neovim doesn't support everything that is in the LSP specification.
+    #  When you add nvim-cmp, luasnip, etc. Neovim now has *more* capabilities.
+    #  So, we create new capabilities with nvim cmp, and then broadcast that to the servers.
+    # NOTE: This is done automatically by Nixvim when enabling cmp-nvim-lsp below is an example if you did want to add new capabilities
+    #capabilities = ''
+    #  capabilities = vim.tbl_deep_extend('force', capabilities, require('cmp_nvim_lsp').default_capabilities())
+    #'';
+
+    # This function gets run when an LSP attaches to a particular buffer.
+    #   That is to say, every time a new file is opened that is associated with
+    #   an lsp (for example, opening `main.rs` is associated with `rust_analyzer`) this
+    #   function will be executred to configure the current buffer
+    # NOTE: This is an example of an attribute that takes raw lua
+    onAttach = ''
+      -- NOTE: Remember that Lua is a real programming language, and as such it is possible
+      -- to define small helper and utility functions so you don't have to repeat yourself.
+      --
+      -- In this case, we create a function that lets us more easily define mappings specific
+      -- for LSP related items. It sets the mode, buffer and description for us each time.
+      local map = function(keys, func, desc)
+        vim.keymap.set('n', keys, func, { buffer = bufnr, desc = 'LSP: ' .. desc })
+      end
+
+      -- The following two autocommands are used to highlight references of the
+      -- word under the cursor when your cursor rests there for a little while.
+      --    See `:help CursorHold` for information about when this is executed
+      --
+      -- When you move your cursor, the highlights will be cleared (the second autocommand).
+      if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_documentHighlight) then
+        local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = false })
+        vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
+          buffer = bufnr,
+          group = highlight_augroup,
+          callback = vim.lsp.buf.document_highlight,
+        })
+
+        vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
+          buffer = bufnr,
+          group = highlight_augroup,
+          callback = vim.lsp.buf.clear_references,
+        })
+
+        vim.api.nvim_create_autocmd('LspDetach', {
+          group = vim.api.nvim_create_augroup('kickstart-lsp-detach', { clear = true }),
+          callback = function(event2)
+            vim.lsp.buf.clear_references()
+            vim.api.nvim_clear_autocmds { group = 'kickstart-lsp-highlight', buffer = event2.buf }
+          end,
+        })
+      end
+
+      -- The following autocommand is used to enable inlay hints in your
+      -- code, if the language server you are using supports them
+      --
+      -- This may be unwanted, since they displace some of your code
+      if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
+        map('<leader>th', function()
+          vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled { bufnr = event.buf })
+        end, '[T]oggle Inlay [H]ints')
+      end
+    '';
   };
 }

--- a/plugins/mini.nix
+++ b/plugins/mini.nix
@@ -1,50 +1,48 @@
 {
-  programs.nixvim = {
-    # Collection of various small independent plugins/modules
-    # https://nix-community.github.io/nixvim/plugins/mini.html
-    plugins.mini = {
-      enable = true;
+  # Collection of various small independent plugins/modules
+  # https://nix-community.github.io/nixvim/plugins/mini.html
+  plugins.mini = {
+    enable = true;
 
-      modules = {
-        # Better Around/Inside textobjects
-        #
-        # Examples:
-        #  - va)  - [V]isually select [A]round [)]paren
-        #  - yinq - [Y]ank [I]nside [N]ext [Q]uote
-        #  - ci'  - [C]hange [I]nside [']quote
-        ai = {
-          n_lines = 500;
-        };
-
-        # Add/delete/replace surroundings (brackets, quotes, etc.)
-        #
-        # Examples:
-        #  - saiw) - [S]urround [A]dd [I]nner [W]ord [)]Paren
-        #  - sd'   - [S]urround [D]elete [']quotes
-        #  - sr)'  - [S]urround [R]eplace [)] [']
-        surround = {
-        };
-
-        # Simple and easy statusline.
-        #  You could remove this setup call if you don't like it,
-        #  and try some other statusline plugin
-        statusline = {
-          use_icons.__raw = "vim.g.have_nerd_font";
-        };
-
-        # ... and there is more!
-        # Check out: https://github.com/echasnovski/mini.nvim
+    modules = {
+      # Better Around/Inside textobjects
+      #
+      # Examples:
+      #  - va)  - [V]isually select [A]round [)]paren
+      #  - yinq - [Y]ank [I]nside [N]ext [Q]uote
+      #  - ci'  - [C]hange [I]nside [']quote
+      ai = {
+        n_lines = 500;
       };
-    };
 
-    # You can configure sections in the statusline by overriding their
-    # default behavior. For example, here we set the section for
-    # cursor location to LINE:COLUMN
-    # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraconfiglu#extraconfiglua
-    extraConfigLua = ''
-      require('mini.statusline').section_location = function()
-        return '%2l:%-2v'
-      end
-    '';
+      # Add/delete/replace surroundings (brackets, quotes, etc.)
+      #
+      # Examples:
+      #  - saiw) - [S]urround [A]dd [I]nner [W]ord [)]Paren
+      #  - sd'   - [S]urround [D]elete [']quotes
+      #  - sr)'  - [S]urround [R]eplace [)] [']
+      surround = {
+      };
+
+      # Simple and easy statusline.
+      #  You could remove this setup call if you don't like it,
+      #  and try some other statusline plugin
+      statusline = {
+        use_icons.__raw = "vim.g.have_nerd_font";
+      };
+
+      # ... and there is more!
+      # Check out: https://github.com/echasnovski/mini.nvim
+    };
   };
+
+  # You can configure sections in the statusline by overriding their
+  # default behavior. For example, here we set the section for
+  # cursor location to LINE:COLUMN
+  # https://nix-community.github.io/nixvim/NeovimOptions/index.html?highlight=extraconfiglu#extraconfiglua
+  extraConfigLua = ''
+    require('mini.statusline').section_location = function()
+      return '%2l:%-2v'
+    end
+  '';
 }

--- a/plugins/nvim-cmp.nix
+++ b/plugins/nvim-cmp.nix
@@ -1,129 +1,127 @@
 {
-  programs.nixvim = {
-    # `friendly-snippets` contains a variety of premade snippets
-    #    See the README about individual language/framework/plugin snippets:
-    #    https://github.com/rafamadriz/friendly-snippets
-    # https://nix-community.github.io/nixvim/plugins/friendly-snippets.html
-    # plugins.friendly-snippets = {
-    #   enable = true;
-    # };
+  # `friendly-snippets` contains a variety of premade snippets
+  #    See the README about individual language/framework/plugin snippets:
+  #    https://github.com/rafamadriz/friendly-snippets
+  # https://nix-community.github.io/nixvim/plugins/friendly-snippets.html
+  # plugins.friendly-snippets = {
+  #   enable = true;
+  # };
 
-    plugins.lazydev.enable = true; # autoEnableSources not enough
-    plugins.luasnip.enable = true; # autoEnableSources not enough
+  plugins.lazydev.enable = true; # autoEnableSources not enough
+  plugins.luasnip.enable = true; # autoEnableSources not enough
 
-    # Autocompletion
-    # See `:help cmp`
-    # https://nix-community.github.io/nixvim/plugins/cmp/index.html
-    plugins.cmp = {
-      enable = true;
+  # Autocompletion
+  # See `:help cmp`
+  # https://nix-community.github.io/nixvim/plugins/cmp/index.html
+  plugins.cmp = {
+    enable = true;
 
-      settings = {
-        snippet = {
-          expand = ''
-            function(args)
-              require('luasnip').lsp_expand(args.body)
-            end
-          '';
-        };
-
-        completion = {
-          completeopt = "menu,menuone,noinsert";
-        };
-
-        # For an understanding of why these mappings were
-        # chosen, you will need to read `:help ins-completion`
-        #
-        # No, but seriously. Please read `:help ins-completion`, it is really good!
-        mapping = {
-          # Select the [n]ext item
-          "<C-n>" = "cmp.mapping.select_next_item()";
-          # Select the [p]revious item
-          "<C-p>" = "cmp.mapping.select_prev_item()";
-
-          # Scroll the documentation window [b]ack / [f]orward
-          "<C-b>" = "cmp.mapping.scroll_docs(-4)";
-          "<C-f>" = "cmp.mapping.scroll_docs(4)";
-
-          # Accept ([y]es) the completion.
-          #  This will auto-import if your LSP supports it.
-          #  This will expand snippets if the LSP sent a snippet.
-          "<C-y>" = "cmp.mapping.confirm { select = true }";
-
-          # If you prefer more traditional completion keymaps,
-          # you can uncomment the following lines.
-          # "<CR>" = "cmp.mapping.confirm { select = true }";
-          # "<Tab>" = "cmp.mapping.select_next_item()";
-          # "<S-Tab>" = "cmp.mapping.select_prev_item()";
-
-          # Manually trigger a completion from nvim-cmp.
-          #  Generally you don't need this, because nvim-cmp will display
-          #  completions whenever it has completion options available.
-          "<C-Space>" = "cmp.mapping.complete {}";
-
-          # Think of <c-l> as moving to the right of your snippet expansion.
-          #  So if you have a snippet that's like:
-          #  function $name($args)
-          #    $body
-          #  end
-          #
-          # <c-l> will move you to the right of each of the expansion locations.
-          # <c-h> is similar, except moving you backwards.
-          "<C-l>" = ''
-            cmp.mapping(function()
-              if luasnip.expand_or_locally_jumpable() then
-                luasnip.expand_or_jump()
-              end
-            end, { 'i', 's' })
-          '';
-          "<C-h>" = ''
-            cmp.mapping(function()
-              if luasnip.locally_jumpable(-1) then
-                luasnip.jump(-1)
-              end
-            end, { 'i', 's' })
-          '';
-
-          # For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
-          #    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
-        };
-
-        # Dependencies
-        #
-        # WARNING: If plugins.cmp.autoEnableSources Nixivm will automatically enable the
-        # corresponding source plugins. This will work only when this option is set to a list.
-        # If you use a raw lua string, you will need to explicitly enable the relevant source
-        # plugins in your nixvim configuration.
-        # See list of most cmp source plugins that are autoloaded by defining the source:
-        # https://github.com/nix-community/nixvim/blob/main/plugins/cmp/sources/default.nix
-        sources = [
-          # https://nix-community.github.io/nixvim/plugins/lazydev/index.html
-          {
-            name = "lazydev";
-            # set group index to 0 to skip loading LuaLS completions as lazydev recommends it
-            group_index = 0;
-          }
-          # Adds other completion capabilites.
-          #  nvim-cmp does not ship with all sources by default. They are split
-          #  into multiple repos for maintenance purposes.
-          # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp.html
-          {
-            name = "nvim_lsp";
-          }
-          # Snippet Engine & its associated nvim-cmp source
-          # https://nix-community.github.io/nixvim/plugins/luasnip/index.html
-          {
-            name = "luasnip";
-          }
-          # https://nix-community.github.io/nixvim/plugins/cmp-path.html
-          {
-            name = "path";
-          }
-          # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp-signature-help.html
-          {
-            name = "nvim_lsp_signature_help";
-          }
-        ];
+    settings = {
+      snippet = {
+        expand = ''
+          function(args)
+            require('luasnip').lsp_expand(args.body)
+          end
+        '';
       };
+
+      completion = {
+        completeopt = "menu,menuone,noinsert";
+      };
+
+      # For an understanding of why these mappings were
+      # chosen, you will need to read `:help ins-completion`
+      #
+      # No, but seriously. Please read `:help ins-completion`, it is really good!
+      mapping = {
+        # Select the [n]ext item
+        "<C-n>" = "cmp.mapping.select_next_item()";
+        # Select the [p]revious item
+        "<C-p>" = "cmp.mapping.select_prev_item()";
+
+        # Scroll the documentation window [b]ack / [f]orward
+        "<C-b>" = "cmp.mapping.scroll_docs(-4)";
+        "<C-f>" = "cmp.mapping.scroll_docs(4)";
+
+        # Accept ([y]es) the completion.
+        #  This will auto-import if your LSP supports it.
+        #  This will expand snippets if the LSP sent a snippet.
+        "<C-y>" = "cmp.mapping.confirm { select = true }";
+
+        # If you prefer more traditional completion keymaps,
+        # you can uncomment the following lines.
+        # "<CR>" = "cmp.mapping.confirm { select = true }";
+        # "<Tab>" = "cmp.mapping.select_next_item()";
+        # "<S-Tab>" = "cmp.mapping.select_prev_item()";
+
+        # Manually trigger a completion from nvim-cmp.
+        #  Generally you don't need this, because nvim-cmp will display
+        #  completions whenever it has completion options available.
+        "<C-Space>" = "cmp.mapping.complete {}";
+
+        # Think of <c-l> as moving to the right of your snippet expansion.
+        #  So if you have a snippet that's like:
+        #  function $name($args)
+        #    $body
+        #  end
+        #
+        # <c-l> will move you to the right of each of the expansion locations.
+        # <c-h> is similar, except moving you backwards.
+        "<C-l>" = ''
+          cmp.mapping(function()
+            if luasnip.expand_or_locally_jumpable() then
+              luasnip.expand_or_jump()
+            end
+          end, { 'i', 's' })
+        '';
+        "<C-h>" = ''
+          cmp.mapping(function()
+            if luasnip.locally_jumpable(-1) then
+              luasnip.jump(-1)
+            end
+          end, { 'i', 's' })
+        '';
+
+        # For more advanced Luasnip keymaps (e.g. selecting choice nodes, expansion) see:
+        #    https://github.com/L3MON4D3/LuaSnip?tab=readme-ov-file#keymaps
+      };
+
+      # Dependencies
+      #
+      # WARNING: If plugins.cmp.autoEnableSources Nixivm will automatically enable the
+      # corresponding source plugins. This will work only when this option is set to a list.
+      # If you use a raw lua string, you will need to explicitly enable the relevant source
+      # plugins in your nixvim configuration.
+      # See list of most cmp source plugins that are autoloaded by defining the source:
+      # https://github.com/nix-community/nixvim/blob/main/plugins/cmp/sources/default.nix
+      sources = [
+        # https://nix-community.github.io/nixvim/plugins/lazydev/index.html
+        {
+          name = "lazydev";
+          # set group index to 0 to skip loading LuaLS completions as lazydev recommends it
+          group_index = 0;
+        }
+        # Adds other completion capabilites.
+        #  nvim-cmp does not ship with all sources by default. They are split
+        #  into multiple repos for maintenance purposes.
+        # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp.html
+        {
+          name = "nvim_lsp";
+        }
+        # Snippet Engine & its associated nvim-cmp source
+        # https://nix-community.github.io/nixvim/plugins/luasnip/index.html
+        {
+          name = "luasnip";
+        }
+        # https://nix-community.github.io/nixvim/plugins/cmp-path.html
+        {
+          name = "path";
+        }
+        # https://nix-community.github.io/nixvim/plugins/cmp-nvim-lsp-signature-help.html
+        {
+          name = "nvim_lsp_signature_help";
+        }
+      ];
     };
   };
 }

--- a/plugins/telescope.nix
+++ b/plugins/telescope.nix
@@ -1,171 +1,169 @@
 {
-  programs.nixvim = {
-    # Fuzzy Finder (files, lsp, etc)
-    # https://nix-community.github.io/nixvim/plugins/telescope/index.html
-    plugins.telescope = {
-      # Telescope is a fuzzy finder that comes with a lot of different things that
-      # it can fuzzy find! It's more than just a "file finder", it can search
-      # many different aspects of Neovim, your workspace, LSP, and more!
-      #
-      # The easiest way to use Telescope, is to start by doing something like:
-      #  :Telescope help_tags
-      #
-      # After running this command, a window will open up and you're able to
-      # type in the prompt window. You'll see a list of `help_tags` options and
-      # a corresponding preview of the help.
-      #
-      # Two important keymaps to use while in Telescope are:
-      #  - Insert mode: <c-/>
-      #  - Normal mode: ?
-      #
-      # This opens a window that shows you all of the keymaps for the current
-      # Telescope picker. This is really useful to discover what Telescope can
-      # do as well as how to actually do it!
-      #
-      # [[ Configure Telescope ]]
-      # See `:help telescope` and `:help telescope.setup()`
-      enable = true;
+  # Fuzzy Finder (files, lsp, etc)
+  # https://nix-community.github.io/nixvim/plugins/telescope/index.html
+  plugins.telescope = {
+    # Telescope is a fuzzy finder that comes with a lot of different things that
+    # it can fuzzy find! It's more than just a "file finder", it can search
+    # many different aspects of Neovim, your workspace, LSP, and more!
+    #
+    # The easiest way to use Telescope, is to start by doing something like:
+    #  :Telescope help_tags
+    #
+    # After running this command, a window will open up and you're able to
+    # type in the prompt window. You'll see a list of `help_tags` options and
+    # a corresponding preview of the help.
+    #
+    # Two important keymaps to use while in Telescope are:
+    #  - Insert mode: <c-/>
+    #  - Normal mode: ?
+    #
+    # This opens a window that shows you all of the keymaps for the current
+    # Telescope picker. This is really useful to discover what Telescope can
+    # do as well as how to actually do it!
+    #
+    # [[ Configure Telescope ]]
+    # See `:help telescope` and `:help telescope.setup()`
+    enable = true;
 
-      # Enable Telescope extensions
-      extensions = {
-        # https://github.com/nvim-telescope/telescope-fzf-native.nvim
-        fzf-native.enable = true;
-        # https://github.com/nvim-telescope/telescope-ui-select.nvim
-        ui-select.enable = true;
-      };
-
-      # You can put your default mappings / updates / etc. in here
-      #  See `:help telescope.builtin`
-      keymaps = {
-        "<leader>sh" = {
-          mode = "n";
-          action = "help_tags";
-          options = {
-            desc = "[S]earch [H]elp";
-          };
-        };
-        "<leader>sk" = {
-          mode = "n";
-          action = "keymaps";
-          options = {
-            desc = "[S]earch [K]eymaps";
-          };
-        };
-        "<leader>sf" = {
-          mode = "n";
-          action = "find_files";
-          options = {
-            desc = "[S]earch [F]iles";
-          };
-        };
-        "<leader>ss" = {
-          mode = "n";
-          action = "builtin";
-          options = {
-            desc = "[S]earch [S]elect Telescope";
-          };
-        };
-        "<leader>sw" = {
-          mode = "n";
-          action = "grep_string";
-          options = {
-            desc = "[S]earch current [W]ord";
-          };
-        };
-        "<leader>sg" = {
-          mode = "n";
-          action = "live_grep";
-          options = {
-            desc = "[S]earch by [G]rep";
-          };
-        };
-        "<leader>sd" = {
-          mode = "n";
-          action = "diagnostics";
-          options = {
-            desc = "[S]earch [D]iagnostics";
-          };
-        };
-        "<leader>sr" = {
-          mode = "n";
-          action = "resume";
-          options = {
-            desc = "[S]earch [R]esume";
-          };
-        };
-        "<leader>s" = {
-          mode = "n";
-          action = "oldfiles";
-          options = {
-            desc = "[S]earch Recent Files ('.' for repeat)";
-          };
-        };
-        "<leader><leader>" = {
-          mode = "n";
-          action = "buffers";
-          options = {
-            desc = "[ ] Find existing buffers";
-          };
-        };
-      };
-      settings = {
-        extensions.__raw = "{ ['ui-select'] = { require('telescope.themes').get_dropdown() } }";
-      };
+    # Enable Telescope extensions
+    extensions = {
+      # https://github.com/nvim-telescope/telescope-fzf-native.nvim
+      fzf-native.enable = true;
+      # https://github.com/nvim-telescope/telescope-ui-select.nvim
+      ui-select.enable = true;
     };
 
-    # https://nix-community.github.io/nixvim/keymaps/index.html
-    keymaps = [
-      # Slightly advanced example of overriding default behavior and theme
-      {
+    # You can put your default mappings / updates / etc. in here
+    #  See `:help telescope.builtin`
+    keymaps = {
+      "<leader>sh" = {
         mode = "n";
-        key = "<leader>/";
-        # You can pass additional configuration to Telescope to change the theme, layout, etc.
-        action.__raw = ''
-          function()
-            require('telescope.builtin').current_buffer_fuzzy_find(
-              require('telescope.themes').get_dropdown {
-                winblend = 10,
-                previewer = false
-              }
-            )
-          end
-        '';
+        action = "help_tags";
         options = {
-          desc = "[/] Fuzzily search in current buffer";
+          desc = "[S]earch [H]elp";
         };
-      }
-      {
+      };
+      "<leader>sk" = {
         mode = "n";
-        key = "<leader>s/";
-        # It's also possible to pass additional configuration options.
-        #  See `:help telescope.builtin.live_grep()` for information about particular keys
-        action.__raw = ''
-          function()
-            require('telescope.builtin').live_grep {
-              grep_open_files = true,
-              prompt_title = 'Live Grep in Open Files'
-            }
-          end
-        '';
+        action = "keymaps";
         options = {
-          desc = "[S]earch [/] in Open Files";
+          desc = "[S]earch [K]eymaps";
         };
-      }
-      # Shortcut for searching your Neovim configuration files
-      {
+      };
+      "<leader>sf" = {
         mode = "n";
-        key = "<leader>sn";
-        action.__raw = ''
-          function()
-            require('telescope.builtin').find_files {
-              cwd = vim.fn.stdpath 'config'
-            }
-          end
-        '';
+        action = "find_files";
         options = {
-          desc = "[S]earch [N]eovim files";
+          desc = "[S]earch [F]iles";
         };
-      }
-    ];
+      };
+      "<leader>ss" = {
+        mode = "n";
+        action = "builtin";
+        options = {
+          desc = "[S]earch [S]elect Telescope";
+        };
+      };
+      "<leader>sw" = {
+        mode = "n";
+        action = "grep_string";
+        options = {
+          desc = "[S]earch current [W]ord";
+        };
+      };
+      "<leader>sg" = {
+        mode = "n";
+        action = "live_grep";
+        options = {
+          desc = "[S]earch by [G]rep";
+        };
+      };
+      "<leader>sd" = {
+        mode = "n";
+        action = "diagnostics";
+        options = {
+          desc = "[S]earch [D]iagnostics";
+        };
+      };
+      "<leader>sr" = {
+        mode = "n";
+        action = "resume";
+        options = {
+          desc = "[S]earch [R]esume";
+        };
+      };
+      "<leader>s" = {
+        mode = "n";
+        action = "oldfiles";
+        options = {
+          desc = "[S]earch Recent Files ('.' for repeat)";
+        };
+      };
+      "<leader><leader>" = {
+        mode = "n";
+        action = "buffers";
+        options = {
+          desc = "[ ] Find existing buffers";
+        };
+      };
+    };
+    settings = {
+      extensions.__raw = "{ ['ui-select'] = { require('telescope.themes').get_dropdown() } }";
+    };
   };
+
+  # https://nix-community.github.io/nixvim/keymaps/index.html
+  keymaps = [
+    # Slightly advanced example of overriding default behavior and theme
+    {
+      mode = "n";
+      key = "<leader>/";
+      # You can pass additional configuration to Telescope to change the theme, layout, etc.
+      action.__raw = ''
+        function()
+          require('telescope.builtin').current_buffer_fuzzy_find(
+            require('telescope.themes').get_dropdown {
+              winblend = 10,
+              previewer = false
+            }
+          )
+        end
+      '';
+      options = {
+        desc = "[/] Fuzzily search in current buffer";
+      };
+    }
+    {
+      mode = "n";
+      key = "<leader>s/";
+      # It's also possible to pass additional configuration options.
+      #  See `:help telescope.builtin.live_grep()` for information about particular keys
+      action.__raw = ''
+        function()
+          require('telescope.builtin').live_grep {
+            grep_open_files = true,
+            prompt_title = 'Live Grep in Open Files'
+          }
+        end
+      '';
+      options = {
+        desc = "[S]earch [/] in Open Files";
+      };
+    }
+    # Shortcut for searching your Neovim configuration files
+    {
+      mode = "n";
+      key = "<leader>sn";
+      action.__raw = ''
+        function()
+          require('telescope.builtin').find_files {
+            cwd = vim.fn.stdpath 'config'
+          }
+        end
+      '';
+      options = {
+        desc = "[S]earch [N]eovim files";
+      };
+    }
+  ];
 }

--- a/plugins/todo-comments.nix
+++ b/plugins/todo-comments.nix
@@ -1,12 +1,10 @@
 {
-  programs.nixvim = {
-    # Highlight todo, notes, etc in comments
-    # https://nix-community.github.io/nixvim/plugins/todo-comments/index.html
-    plugins.todo-comments = {
-      enable = true;
-      settings = {
-        signs = true;
-      };
+  # Highlight todo, notes, etc in comments
+  # https://nix-community.github.io/nixvim/plugins/todo-comments/index.html
+  plugins.todo-comments = {
+    enable = true;
+    settings = {
+      signs = true;
     };
   };
 }

--- a/plugins/treesitter.nix
+++ b/plugins/treesitter.nix
@@ -1,47 +1,45 @@
 {
-  programs.nixvim = {
-    # Highlight, edit, and navigate code
-    # https://nix-community.github.io/nixvim/plugins/treesitter/index.html
-    plugins.treesitter = {
-      enable = true;
+  # Highlight, edit, and navigate code
+  # https://nix-community.github.io/nixvim/plugins/treesitter/index.html
+  plugins.treesitter = {
+    enable = true;
 
-      # TODO: Don't think I need this as nixGrammars is true which should auto install these???
-      settings = {
-        ensureInstalled = [
-          "bash"
-          "c"
-          "diff"
-          "html"
-          "lua"
-          "luadoc"
-          "markdown"
-          "markdown_inline"
-          "query"
-          "vim"
-          "vimdoc"
-        ];
+    # TODO: Don't think I need this as nixGrammars is true which should auto install these???
+    settings = {
+      ensureInstalled = [
+        "bash"
+        "c"
+        "diff"
+        "html"
+        "lua"
+        "luadoc"
+        "markdown"
+        "markdown_inline"
+        "query"
+        "vim"
+        "vimdoc"
+      ];
 
-        highlight = {
-          enable = true;
+      highlight = {
+        enable = true;
 
-          # Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
-          additional_vim_regex_highlighting = true;
-        };
-
-        indent = {
-          enable = true;
-          disable = [
-            "ruby"
-          ];
-        };
-
-        # There are additional nvim-treesitter modules that you can use to interact
-        # with nvim-treesitter. You should go explore a few and see what interests you:
-        #
-        #    - Incremental selection: Included, see `:help nvim-treesitter-incremental-selection-mod`
-        #    - Show your current context: https://nix-community.github.io/nixvim/plugins/treesitter-context/index.html
-        #    - Treesitter + textobjects: https://nix-community.github.io/nixvim/plugins/treesitter-textobjects/index.html
+        # Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
+        additional_vim_regex_highlighting = true;
       };
+
+      indent = {
+        enable = true;
+        disable = [
+          "ruby"
+        ];
+      };
+
+      # There are additional nvim-treesitter modules that you can use to interact
+      # with nvim-treesitter. You should go explore a few and see what interests you:
+      #
+      #    - Incremental selection: Included, see `:help nvim-treesitter-incremental-selection-mod`
+      #    - Show your current context: https://nix-community.github.io/nixvim/plugins/treesitter-context/index.html
+      #    - Treesitter + textobjects: https://nix-community.github.io/nixvim/plugins/treesitter-textobjects/index.html
     };
   };
 }

--- a/plugins/which-key.nix
+++ b/plugins/which-key.nix
@@ -1,47 +1,45 @@
 {
-  programs.nixvim = {
-    # Useful plugin to show you pending keybinds.
-    # https://nix-community.github.io/nixvim/plugins/which-key/index.html
-    plugins.which-key = {
-      enable = true;
+  # Useful plugin to show you pending keybinds.
+  # https://nix-community.github.io/nixvim/plugins/which-key/index.html
+  plugins.which-key = {
+    enable = true;
 
-      # Document existing key chains
-      settings = {
-        spec = [
-          {
-            __unkeyed-1 = "<leader>c";
-            group = "[C]ode";
-          }
-          {
-            __unkeyed-1 = "<leader>d";
-            group = "[D]ocument";
-          }
-          {
-            __unkeyed-1 = "<leader>r";
-            group = "[R]ename";
-          }
-          {
-            __unkeyed-1 = "<leader>s";
-            group = "[S]earch";
-          }
-          {
-            __unkeyed-1 = "<leader>w";
-            group = "[W]orkspace";
-          }
-          {
-            __unkeyed-1 = "<leader>t";
-            group = "[T]oggle";
-          }
-          {
-            __unkeyed-1 = "<leader>h";
-            group = "Git [H]unk";
-            mode = [
-              "n"
-              "v"
-            ];
-          }
-        ];
-      };
+    # Document existing key chains
+    settings = {
+      spec = [
+        {
+          __unkeyed-1 = "<leader>c";
+          group = "[C]ode";
+        }
+        {
+          __unkeyed-1 = "<leader>d";
+          group = "[D]ocument";
+        }
+        {
+          __unkeyed-1 = "<leader>r";
+          group = "[R]ename";
+        }
+        {
+          __unkeyed-1 = "<leader>s";
+          group = "[S]earch";
+        }
+        {
+          __unkeyed-1 = "<leader>w";
+          group = "[W]orkspace";
+        }
+        {
+          __unkeyed-1 = "<leader>t";
+          group = "[T]oggle";
+        }
+        {
+          __unkeyed-1 = "<leader>h";
+          group = "Git [H]unk";
+          mode = [
+            "n"
+            "v"
+          ];
+        }
+      ];
     };
   };
 }


### PR DESCRIPTION
This PR moves plugin imports of plugins inside `programs.nixvim`, and removes the recurring option in individual plugin modules
The (more trivial) reason is so that the option does not need to be repeated in the individual modules.

The commit actually stems from another PR (coming) where I updated the `standalone` branch to main, minimizing the differences between the two branches.
