### PR TITLE
fix Recent files keymap

### DIFF
--- a/plugins/telescope.nix
+++ b/plugins/telescope.nix
@@ -93,7 +93,7 @@
             desc = "[S]earch [R]esume";
           };
         };
-        "<leader>s" = {
+        "<leader>s." = {
           mode = "n";
           action = "oldfiles";
           options = {


### PR DESCRIPTION
`<leader>s.` with dot

see https://github.com/nvim-lua/kickstart.nvim/blob/d350db2449da40df003c40d440f909d74e2d4e70/init.lua#L429