### PR TITLE
Fix typo in gitsigns keybinding with unstage hunk

### DIFF
--- a/config/plugins/kickstart/gitsigns.nix
+++ b/config/plugins/kickstart/gitsigns.nix
@@ -119,7 +119,7 @@
       key = "<leader>hu";
       action.__raw = ''
         function()
-          require('gitsigns').stage_hunk()
+          require('gitsigns').undo_stage_hunk()
         end
       '';
       options = {


### PR DESCRIPTION
There is a minor typo in gitsigns keybinding where the unstage hunk keybinding just staged the hunk instead